### PR TITLE
Add tests for LanguageValidator

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,7 +18,6 @@
         <caffeine.version>3.1.8</caffeine.version>
         <liquibase.version>4.25.1</liquibase.version>
         <jackson.version>2.16.1</jackson.version>
-        <powermock.version>2.0.9</powermock.version>
         <google.cloud.storage.version>2.32.1</google.cloud.storage.version>
         <azure.webapp.maven.plugin.version>2.13.0</azure.webapp.maven.plugin.version>
         <tngtech.version>1.13.1</tngtech.version>
@@ -121,12 +120,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/core/src/test/java/greencity/validator/LanguageTranslationValidatorTest.java
+++ b/core/src/test/java/greencity/validator/LanguageTranslationValidatorTest.java
@@ -16,7 +16,7 @@ import static greencity.ModelUtils.getLanguageDTO;
 import static greencity.ModelUtils.getLanguageTranslationDTO;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 class LanguageTranslationValidatorTest {

--- a/core/src/test/java/greencity/validator/LanguageValidatorTest.java
+++ b/core/src/test/java/greencity/validator/LanguageValidatorTest.java
@@ -39,4 +39,21 @@ public class LanguageValidatorTest {
         languageValidator.initialize(null);
         assertFalse(languageValidator.isValid(Locale.FRENCH, null));
     }
+
+    @Test
+    void isValidFalseWhenNullTest() {
+        List<String> languageCodes = Arrays.asList("en", "ua");
+        when(languageService.findAllLanguageCodes()).thenReturn(languageCodes);
+
+        languageValidator.initialize(null);
+        assertFalse(languageValidator.isValid(Locale.FRENCH, null));
+    }
+
+    @Test
+    void isValidFalseWhenEmptyListTest() {
+        when(languageService.findAllLanguageCodes()).thenReturn(List.of());
+
+        languageValidator.initialize(null);
+        assertFalse(languageValidator.isValid(Locale.FRENCH, null));
+    }
 }

--- a/core/src/test/java/greencity/validator/LanguageValidatorTest.java
+++ b/core/src/test/java/greencity/validator/LanguageValidatorTest.java
@@ -1,0 +1,42 @@
+package greencity.validator;
+
+import greencity.service.LanguageService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+public class LanguageValidatorTest {
+    @InjectMocks
+    private LanguageValidator languageValidator;
+    @Mock
+    private LanguageService languageService;
+
+    @Test
+    void isValidTrueTest() {
+        List<String> languageCodes = Arrays.asList("en", "fr", "ua");
+        when(languageService.findAllLanguageCodes()).thenReturn(languageCodes);
+
+        languageValidator.initialize(null);
+        assertTrue(languageValidator.isValid(Locale.FRENCH, null));
+    }
+
+    @Test
+    void isValidFalseTest() {
+        List<String> languageCodes = Arrays.asList("en", "ua");
+        when(languageService.findAllLanguageCodes()).thenReturn(languageCodes);
+
+        languageValidator.initialize(null);
+        assertFalse(languageValidator.isValid(Locale.FRENCH, null));
+    }
+}

--- a/core/src/test/java/greencity/validator/LanguageValidatorTest.java
+++ b/core/src/test/java/greencity/validator/LanguageValidatorTest.java
@@ -46,7 +46,7 @@ public class LanguageValidatorTest {
         when(languageService.findAllLanguageCodes()).thenReturn(languageCodes);
 
         languageValidator.initialize(null);
-        assertFalse(languageValidator.isValid(Locale.FRENCH, null));
+        assertFalse(languageValidator.isValid(null, null));
     }
 
     @Test


### PR DESCRIPTION
also included here is powermock removal, since (a) it wasn't needed, (b) at least for me and some people in powermock / mockito issues, the tests don't even start with it.

---

Fixes GreenCity-UA-4146-4625-01/Issues#10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added new tests for the language validator to verify correct validation of locales.
  - Updated existing tests to use Mockito for mocking instead of PowerMockito.

- **Chores**
  - Removed PowerMock dependency from the project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->