### PR TITLE
Tests for Mappers 5-10

### DIFF
--- a/service/src/test/java/greencity/mapping/EcoNewsAuthorDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsAuthorDtoMapperTest.java
@@ -13,7 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
-public class EcoNewsAuthorDtoMapperTest {
+class EcoNewsAuthorDtoMapperTest {
     @InjectMocks
     EcoNewsAuthorDtoMapper mapper;
 

--- a/service/src/test/java/greencity/mapping/EcoNewsAuthorDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsAuthorDtoMapperTest.java
@@ -1,0 +1,40 @@
+package greencity.mapping;
+
+import greencity.dto.user.EcoNewsAuthorDto;
+import greencity.entity.User;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+public class EcoNewsAuthorDtoMapperTest {
+    @InjectMocks
+    EcoNewsAuthorDtoMapper mapper;
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setupValidator() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    void convertSuccess() {
+        User author = User.builder()
+                .id(1L)
+                .name("test")
+                .build();
+
+        EcoNewsAuthorDto expected = new EcoNewsAuthorDto(1L, "test");
+        EcoNewsAuthorDto actual = mapper.convert(author);
+
+        assertEquals(expected, actual);
+        assertTrue(validator.validate(actual).isEmpty());
+    }
+}

--- a/service/src/test/java/greencity/mapping/EcoNewsCommentDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsCommentDtoMapperTest.java
@@ -1,0 +1,87 @@
+package greencity.mapping;
+
+import greencity.dto.econewscomment.EcoNewsCommentDto;
+import greencity.entity.EcoNewsComment;
+import greencity.entity.User;
+import greencity.enums.CommentStatus;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class EcoNewsCommentDtoMapperTest {
+    @InjectMocks
+    EcoNewsCommentDtoMapper mapper;
+
+    private static User authorUser;
+
+    @BeforeAll
+    static void setup() {
+        authorUser = User.builder()
+                .id(1L)
+                .name("User")
+                .profilePicturePath("http://localhost/image.png")
+                .build();
+    }
+
+    @Test
+    void convertSuccessDeletedComment() {
+        EcoNewsComment comment = EcoNewsComment.builder()
+                .id(1L)
+                .createdDate(LocalDateTime.now().minusDays(1))
+                .modifiedDate(LocalDateTime.now().minusDays(1))
+                .deleted(true)
+                .build();
+
+        EcoNewsCommentDto dto = mapper.convert(comment);
+        assertEquals(CommentStatus.DELETED, dto.getStatus());
+        assertEquals(comment.getId(), dto.getId());
+        assertEquals(comment.getModifiedDate(), dto.getModifiedDate());
+    }
+
+    @Test
+    void convertSuccessOriginalComment() {
+        LocalDateTime createdDate = LocalDateTime.now().minusDays(1);
+
+        EcoNewsComment comment = EcoNewsComment.builder()
+                .id(1L)
+                .createdDate(createdDate)
+                .modifiedDate(createdDate)
+                .text("text")
+                .user(authorUser)
+                .usersLiked(Set.of(authorUser))
+                .currentUserLiked(true)
+                .build();
+
+        EcoNewsCommentDto dto = mapper.convert(comment);
+        assertEquals(CommentStatus.ORIGINAL, dto.getStatus());
+        assertEquals(comment.getId(), dto.getId());
+        assertEquals(comment.getModifiedDate(), dto.getModifiedDate());
+        assertEquals(comment.getText(), dto.getText());
+        assertEquals(comment.isCurrentUserLiked(), dto.isCurrentUserLiked());
+        assertEquals(1, dto.getLikes());
+    }
+
+    @Test
+    void convertSuccessEditedComment() {
+        EcoNewsComment comment = EcoNewsComment.builder()
+                .id(1L)
+                .createdDate(LocalDateTime.now().minusDays(1))
+                .modifiedDate(LocalDateTime.now())
+                .text("text")
+                .user(authorUser)
+                .usersLiked(Set.of(authorUser))
+                .currentUserLiked(true)
+                .build();
+
+        EcoNewsCommentDto dto = mapper.convert(comment);
+        assertEquals(CommentStatus.EDITED, dto.getStatus());
+    }
+}

--- a/service/src/test/java/greencity/mapping/EcoNewsCommentDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsCommentDtoMapperTest.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
-public class EcoNewsCommentDtoMapperTest {
+class EcoNewsCommentDtoMapperTest {
     @InjectMocks
     EcoNewsCommentDtoMapper mapper;
 

--- a/service/src/test/java/greencity/mapping/EcoNewsCommentVOMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsCommentVOMapperTest.java
@@ -1,0 +1,53 @@
+package greencity.mapping;
+
+import greencity.ModelUtils;
+import greencity.dto.econewscomment.EcoNewsCommentVO;
+import greencity.entity.EcoNewsComment;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class EcoNewsCommentVOMapperTest {
+    @InjectMocks
+    EcoNewsCommentVOMapper mapper;
+    
+    @Test
+    void convertWithNullParent() {
+        EcoNewsComment comment = ModelUtils.getEcoNewsComment();
+        comment.setUsersLiked(Set.of(ModelUtils.getUser()));
+
+        EcoNewsCommentVO vo = mapper.convert(comment);
+        
+        assertEquals(comment.getId(), vo.getId());
+        assertEquals(ModelUtils.getUserVO(), vo.getUser());
+        assertEquals(comment.getCreatedDate(), vo.getCreatedDate());
+        assertEquals(comment.getModifiedDate(), vo.getModifiedDate());
+        assertEquals(comment.getText(), vo.getText());
+        assertEquals(comment.isDeleted(), vo.isDeleted());
+        assertEquals(comment.isCurrentUserLiked(), vo.isCurrentUserLiked());
+        assertEquals(comment.getCreatedDate(), vo.getCreatedDate());
+        assertEquals(Set.of(ModelUtils.getUserVO()), vo.getUsersLiked());
+        assertEquals(ModelUtils.getEcoNewsVO(), vo.getEcoNews());
+    }
+
+    @Test
+    void convertWithParent() {
+        EcoNewsComment comment = ModelUtils.getEcoNewsComment();
+        comment.setUsersLiked(Set.of());
+
+        EcoNewsComment parent = new EcoNewsComment(comment.getId() + 1, comment.getText(), comment.getCreatedDate(),
+                comment.getModifiedDate(), null, List.of(comment), comment.getUser(),
+                comment.getEcoNews(), comment.isDeleted(), comment.isCurrentUserLiked(), comment.getUsersLiked());
+        comment.setParentComment(parent);
+
+        EcoNewsCommentVO vo = mapper.convert(comment);
+        assertEquals(parent.getId(), vo.getParentComment().getId());
+    }
+}

--- a/service/src/test/java/greencity/mapping/EcoNewsCommentVOMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsCommentVOMapperTest.java
@@ -32,7 +32,6 @@ public class EcoNewsCommentVOMapperTest {
         assertEquals(comment.getText(), vo.getText());
         assertEquals(comment.isDeleted(), vo.isDeleted());
         assertEquals(comment.isCurrentUserLiked(), vo.isCurrentUserLiked());
-        assertEquals(comment.getCreatedDate(), vo.getCreatedDate());
         assertEquals(Set.of(ModelUtils.getUserVO()), vo.getUsersLiked());
         assertEquals(ModelUtils.getEcoNewsVO(), vo.getEcoNews());
     }

--- a/service/src/test/java/greencity/mapping/EcoNewsCommentVOMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsCommentVOMapperTest.java
@@ -14,7 +14,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
-public class EcoNewsCommentVOMapperTest {
+class EcoNewsCommentVOMapperTest {
     @InjectMocks
     EcoNewsCommentVOMapper mapper;
     

--- a/service/src/test/java/greencity/mapping/EcoNewsDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsDtoMapperTest.java
@@ -1,0 +1,113 @@
+package greencity.mapping;
+
+import greencity.ModelUtils;
+import greencity.dto.econews.EcoNewsDto;
+import greencity.entity.EcoNews;
+import greencity.entity.EcoNewsComment;
+import greencity.entity.Tag;
+import greencity.entity.localization.TagTranslation;
+import greencity.enums.TagType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class EcoNewsDtoMapperTest {
+    @InjectMocks
+    private EcoNewsDtoMapper mapper;
+
+    @Test
+    void convertNoTags() {
+        EcoNews news = ModelUtils.getEcoNews();
+        news.setTags(List.of());
+
+        EcoNewsDto dto = mapper.convert(news);
+        assertEquals(dto.getId(), news.getId());
+        assertEquals(dto.getTitle(), news.getTitle());
+        assertEquals(dto.getContent(), news.getText());
+        assertEquals(dto.getAuthor().getId(), news.getAuthor().getId());
+        assertEquals(dto.getAuthor().getName(), news.getAuthor().getName());
+        assertEquals(dto.getCreationDate(), news.getCreationDate());
+        assertEquals(dto.getImagePath(), news.getImagePath());
+        assertEquals(dto.getLikes(), news.getUsersLikedNews().size());
+        assertEquals(dto.getDislikes(), news.getUsersDislikedNews().size());
+        assertEquals(dto.getShortInfo(), news.getShortInfo());
+        assertEquals(0, dto.getTags().size());
+        assertEquals(0, dto.getTagsUa().size());
+    }
+
+    @Test
+    void convertWithTagsEn() {
+        EcoNews news = ModelUtils.getEcoNews();
+        news.setTags(List.of(
+                Tag.builder()
+                        .id(1L)
+                        .type(TagType.ECO_NEWS)
+                        .tagTranslations(List.of(
+                                TagTranslation.builder()
+                                        .language(ModelUtils.getLanguage())
+                                        .name("Test Tag")
+                                        .build()
+                        ))
+                        .build()
+        ));
+
+        EcoNewsDto dto = mapper.convert(news);
+        assertEquals(1, dto.getTags().size());
+        assertEquals(0, dto.getTagsUa().size());
+    }
+
+    @Test
+    void convertWithTagsUa() {
+        EcoNews news = ModelUtils.getEcoNews();
+        news.setTags(List.of(
+                Tag.builder()
+                        .id(1L)
+                        .type(TagType.ECO_NEWS)
+                        .tagTranslations(List.of(
+                                TagTranslation.builder()
+                                        .language(ModelUtils.getLanguageUa())
+                                        .name("Test Tag")
+                                        .build()
+                        ))
+                        .build()
+        ));
+
+        EcoNewsDto dto = mapper.convert(news);
+        assertEquals(0, dto.getTags().size());
+        assertEquals(1, dto.getTagsUa().size());
+    }
+
+    @Test
+    void convertWithComments() {
+        EcoNews news = ModelUtils.getEcoNews();
+        news.setEcoNewsComments(List.of(
+                EcoNewsComment.builder()
+                        .deleted(false)
+                        .text("not deleted")
+                        .build()
+        ));
+
+        EcoNewsDto dto = mapper.convert(news);
+        assertEquals(1, dto.getCountComments());
+    }
+
+    @Test
+    void convertWithDeletedComments() {
+        EcoNews news = ModelUtils.getEcoNews();
+        news.setEcoNewsComments(List.of(
+                EcoNewsComment.builder()
+                        .deleted(true)
+                        .text("deleted")
+                        .build()
+        ));
+
+        EcoNewsDto dto = mapper.convert(news);
+        assertEquals(0, dto.getCountComments());
+    }
+}

--- a/service/src/test/java/greencity/mapping/EcoNewsDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsDtoMapperTest.java
@@ -17,7 +17,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
-public class EcoNewsDtoMapperTest {
+class EcoNewsDtoMapperTest {
     @InjectMocks
     private EcoNewsDtoMapper mapper;
 

--- a/service/src/test/java/greencity/mapping/EcoNewsVOMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsVOMapperTest.java
@@ -21,7 +21,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
-public class EcoNewsVOMapperTest {
+class EcoNewsVOMapperTest {
 
     @InjectMocks
     private EcoNewsVOMapper mapper;

--- a/service/src/test/java/greencity/mapping/EcoNewsVOMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsVOMapperTest.java
@@ -1,0 +1,130 @@
+package greencity.mapping;
+
+import greencity.ModelUtils;
+import greencity.dto.econews.EcoNewsVO;
+import greencity.dto.econewscomment.EcoNewsCommentVO;
+import greencity.dto.tag.TagTranslationVO;
+import greencity.dto.tag.TagVO;
+import greencity.dto.user.UserVO;
+import greencity.entity.EcoNews;
+import greencity.entity.EcoNewsComment;
+import greencity.entity.Tag;
+import greencity.entity.localization.TagTranslation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class EcoNewsVOMapperTest {
+
+    @InjectMocks
+    private EcoNewsVOMapper mapper;
+
+    private static EcoNews createEcoNews() {
+        EcoNews news = ModelUtils.getEcoNews();
+        news.setTags(List.of());
+        news.setUsersDislikedNews(Set.of());
+        news.setUsersLikedNews(Set.of());
+        news.setEcoNewsComments(List.of());
+        return news;
+    }
+
+    @Test
+    void convertSuccessBasic() {
+        EcoNews news = createEcoNews();
+
+        EcoNewsVO vo = mapper.convert(news);
+
+        assertEquals(news.getId(), vo.getId());
+        assertEquals(news.getAuthor().getId(), vo.getAuthor().getId());
+        assertEquals(news.getAuthor().getName(), vo.getAuthor().getName());
+        assertEquals(news.getAuthor().getUserStatus(), vo.getAuthor().getUserStatus());
+        assertEquals(news.getAuthor().getRole(), vo.getAuthor().getRole());
+        assertEquals(news.getCreationDate(), vo.getCreationDate());
+        assertEquals(news.getImagePath(), vo.getImagePath());
+        assertEquals(news.getSource(), vo.getSource());
+        assertEquals(news.getTitle(), vo.getTitle());
+        assertEquals(news.getText(), vo.getText());
+    }
+
+    @Test
+    void convertSuccessWithTags() {
+        EcoNews news = createEcoNews();
+        news.setTags(List.of(
+                Tag.builder()
+                        .id(1L)
+                        .tagTranslations(List.of(
+                                TagTranslation.builder()
+                                        .name("name")
+                                        .id(1L)
+                                        .language(ModelUtils.getLanguage())
+                                        .build()
+                        ))
+                        .build()
+        ));
+
+        EcoNewsVO vo = mapper.convert(news);
+        assertEquals(1, vo.getTags().size());
+
+        TagVO tagVo = vo.getTags().getFirst();
+        assertEquals(1, tagVo.getId());
+        assertEquals(1, tagVo.getTagTranslations().size());
+
+        TagTranslationVO translationVo = tagVo.getTagTranslations().getFirst();
+        assertEquals(1, translationVo.getId());
+        assertEquals("name", translationVo.getName());
+        assertEquals(ModelUtils.getLanguageVO(), translationVo.getLanguageVO());
+    }
+
+    @Test
+    void convertSuccessWithUsersLiked() {
+        EcoNews news = createEcoNews();
+        news.setUsersLikedNews(Set.of(ModelUtils.getUser()));
+
+        EcoNewsVO vo = mapper.convert(news);
+        assertEquals(1, vo.getUsersLikedNews().size());
+        assertEquals(1L, vo.getUsersLikedNews().toArray(new UserVO[0])[0].getId());
+    }
+
+    @Test
+    void convertSuccessWithUsersDisliked() {
+        EcoNews news = createEcoNews();
+        news.setUsersDislikedNews(Set.of(ModelUtils.getUser()));
+
+        EcoNewsVO vo = mapper.convert(news);
+        assertEquals(1, vo.getUsersDislikedNews().size());
+        assertEquals(1L, vo.getUsersDislikedNews().toArray(new UserVO[0])[0].getId());
+    }
+
+    @Test
+    void convertSuccessWithComments() {
+        EcoNews news = createEcoNews();
+        news.setEcoNewsComments(List.of(
+                ModelUtils.getEcoNewsComment()
+        ));
+
+        EcoNewsVO vo = mapper.convert(news);
+        assertEquals(1, vo.getEcoNewsComments().size());
+
+        EcoNewsCommentVO commentVo = vo.getEcoNewsComments().getFirst();
+        EcoNewsComment comment = news.getEcoNewsComments().getFirst();
+
+        assertEquals(comment.getId(), commentVo.getId());
+        assertEquals(comment.getCreatedDate(), commentVo.getCreatedDate());
+        assertEquals(comment.getModifiedDate(), commentVo.getModifiedDate());
+        assertEquals(comment.getText(), commentVo.getText());
+        assertEquals(comment.isDeleted(), commentVo.isDeleted());
+        assertEquals(comment.isCurrentUserLiked(), commentVo.isCurrentUserLiked());
+
+        assertEquals(comment.getUser().getId(), commentVo.getUser().getId());
+        assertEquals(comment.getUser().getName(), commentVo.getUser().getName());
+        assertEquals(comment.getUser().getUserStatus(), commentVo.getUser().getUserStatus());
+        assertEquals(comment.getUser().getRole(), commentVo.getUser().getRole());
+    }
+}


### PR DESCRIPTION
Closes GreenCity-UA-4146-4625-01/Issues#129.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for mapping components related to EcoNews and EcoNews comments, including author, comment, and news entity conversions.
  * Tests cover various scenarios such as handling tags in different languages, deleted and non-deleted comments, parent-child comment relationships, and correct mapping of nested collections.
  * Ensured validation of resulting data transfer objects and value objects for correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->