### PR TITLE
Create unit test to HabitController.java #6

### DIFF
--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -97,7 +97,6 @@ public class HabitControllerTest {
     private static final String BASE_URL = "/habit";
     private final Locale LOCALE = Locale.ENGLISH;
     private final Long HABIT_ID = 1L;
-
     @InjectMocks
     HabitController habitController;
     @Mock

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -7,6 +7,7 @@ import greencity.dto.habit.AddCustomHabitDtoResponse;
 import greencity.dto.habit.HabitDto;
 import greencity.dto.habittranslation.HabitTranslationDto;
 import greencity.dto.shoppinglistitem.ShoppingListItemDto;
+import greencity.dto.user.UserProfilePictureDto;
 import greencity.dto.user.UserVO;
 import greencity.service.HabitService;
 import greencity.service.TagsService;
@@ -23,7 +24,6 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.List;
@@ -46,9 +46,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * <ul>
  *     {@code GET /habit/{id}} – Get habit by ID (localized)
  *      <li>
- *          {@link HabitControllerTest#findHabitByIdWithLocaleTranslation_whenHabitExists()}
+ *          {@link HabitControllerTest#shouldReturnExistingDtoWhenHabitIsFound()} ()}
  *      <li>
- *          {@link HabitControllerTest#findHabitByIdWithLocaleTranslation_whenBadRequest400()}
+ *          {@link HabitControllerTest#shouldReturn404WhenPassedWrongId()}
  *      </li>
  * </ul>
  *
@@ -77,17 +77,26 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *          {@link HabitControllerTest#shouldReturnAllHabitTags()}
  *      </li>
  * </ul>
- * <ul>POST /habit/custom – Add new custom habit with multipart image</ul>
- * <ul>GET /habit/{habitId}/friends/profile-pictures – Get profile pictures of friends assigned to habit</ul>
+ * <ul>{@code POST /habit/custom} – Add new custom habit with multipart image
+ *      <li>
+ *          {@link HabitControllerTest#shouldAddNewCustomHabitWithMultipartImage()}
+ *      </li>
+ * </ul>
+ * <ul>{@code GET /habit/{HABIT_ID}/friends/profile-pictures} – Get profile pictures of friends assigned to habit
+ *      <li>
+ *          {@link HabitControllerTest#shouldReturnProfilePicturesOfFriendsAssignedToHabit()}
+ *      </li>
+ * </ul>
  */
 
 @ExtendWith(MockitoExtension.class)
 @WithMockUser(username = "usergreencity@gmail.com", roles = {"USER"})
 public class HabitControllerTest {
 
-    private static final String baseUrl = "/habit";
-    private final Locale locale = Locale.ENGLISH;
-    private final Long habitId = 1L;
+    public static final String IMG_EXAMPLE = "https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg";
+    private static final String BASE_URL = "/habit";
+    private final Locale LOCALE = Locale.ENGLISH;
+    private final Long HABIT_ID = 1L;
     @InjectMocks
     HabitController habitController;
     @Mock
@@ -104,30 +113,30 @@ public class HabitControllerTest {
 
     @Test
     @DisplayName("GET /habit/{id} returns existing DTO when habit is found")
-    void findHabitByIdWithLocaleTranslation_whenHabitExists() throws Exception {
+    void shouldReturnExistingDtoWhenHabitIsFound() throws Exception {
         HabitDto expectedHabitDto = new HabitDto();
-        expectedHabitDto.setId(habitId);
-        expectedHabitDto.setHabitTranslation(new HabitTranslationDto().setLanguageCode(locale.getLanguage()));
+        expectedHabitDto.setId(HABIT_ID);
+        expectedHabitDto.setHabitTranslation(new HabitTranslationDto().setLanguageCode(LOCALE.getLanguage()));
 
-        when(habitService.getByIdAndLanguageCode(habitId, locale.getLanguage())).thenReturn(expectedHabitDto);
+        when(habitService.getByIdAndLanguageCode(HABIT_ID, LOCALE.getLanguage())).thenReturn(expectedHabitDto);
 
-        mockMvc.perform(get(baseUrl + "/" + habitId)
-                        .locale(locale)
+        mockMvc.perform(get(BASE_URL + "/{HABIT_ID}", HABIT_ID)
+                        .header("Accept-Language", LOCALE.getLanguage())
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.habitTranslation.languageCode").value(locale.getLanguage()))
-                .andExpect(jsonPath("$.id").value(habitId));
+                .andExpect(jsonPath("$.habitTranslation.languageCode").value(LOCALE.getLanguage()))
+                .andExpect(jsonPath("$.id").value(HABIT_ID));
 
-        verify(habitService).getByIdAndLanguageCode(habitId, locale.getLanguage());
-
+        verify(habitService).getByIdAndLanguageCode(HABIT_ID, LOCALE.getLanguage());
     }
 
     @Test
     @DisplayName("GET /habit/{id} returns '400 - Bad Request' when passed wrong @id")
-    void findHabitByIdWithLocaleTranslation_whenBadRequest400() throws Exception {
-        String habitId = "abc";
-        mockMvc.perform(get(baseUrl + "/" + habitId)
-                        .locale(locale)
+    void shouldReturn404WhenPassedWrongId() throws Exception {
+        String habitIdStr = "abc";
+
+        mockMvc.perform(get(BASE_URL + "/{HABIT_ID}", habitIdStr)
+                        .header("Accept-Language", LOCALE.getLanguage())
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
 
@@ -137,16 +146,18 @@ public class HabitControllerTest {
     @Test
     @DisplayName("GET /habit returns all default and custom habits")
     void shouldReturnPageableDtoOfHabitDto() throws Exception {
-        List<HabitDto> habits = List.of(new HabitDto().setImage("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg"));
+        List<HabitDto> habits = List.of(new HabitDto().setImage(IMG_EXAMPLE));
         PageableDto<HabitDto> page = new PageableDto<>(habits, 1, 0, 1);
-        when(habitService.getAllHabitsByLanguageCode(any(UserVO.class), any(Pageable.class), eq(locale.getLanguage()))).thenReturn(page);
 
-        mockMvc.perform(get(baseUrl)
+        when(habitService.getAllHabitsByLanguageCode(any(UserVO.class), any(Pageable.class), eq(LOCALE.getLanguage()))).thenReturn(page);
+
+        mockMvc.perform(get(BASE_URL)
+                        .header("Accept-Language", LOCALE.getLanguage())
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("@.page[0].image").value("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg"));
+                .andExpect(jsonPath("@.page[0].image").value(IMG_EXAMPLE));
 
-        verify(habitService).getAllHabitsByLanguageCode(any(UserVO.class), any(Pageable.class), eq(locale.getLanguage()));
+        verify(habitService).getAllHabitsByLanguageCode(any(UserVO.class), any(Pageable.class), eq(LOCALE.getLanguage()));
     }
 
     @Test
@@ -160,11 +171,11 @@ public class HabitControllerTest {
         dto2.setId(11L);
         dto2.setText("Glass bottle");
 
-        when(habitService.getShoppingListForHabit(habitId, locale.getLanguage()))
+        when(habitService.getShoppingListForHabit(HABIT_ID, LOCALE.getLanguage()))
                 .thenReturn(List.of(dto1, dto2));
 
-        mockMvc.perform(get(baseUrl + "/" + habitId + "/shopping-list")
-                        .locale(locale)
+        mockMvc.perform(get(BASE_URL + "/{HABIT_ID}/shopping-list", HABIT_ID)
+                        .header("Accept-Language", LOCALE.getLanguage())
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(10L))
@@ -172,7 +183,7 @@ public class HabitControllerTest {
                 .andExpect(jsonPath("$[1].id").value(11L))
                 .andExpect(jsonPath("$[1].text").value("Glass bottle"));
 
-        verify(habitService).getShoppingListForHabit(habitId, locale.getLanguage());
+        verify(habitService).getShoppingListForHabit(HABIT_ID, LOCALE.getLanguage());
     }
 
     @Test
@@ -183,25 +194,27 @@ public class HabitControllerTest {
         HabitDto dto1 = new HabitDto();
         dto1.setId(1L);
         dto1.setTags(List.of("EVENT"));
-        dto1.setImage("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg");
+        dto1.setImage(IMG_EXAMPLE);
 
         HabitDto dto2 = new HabitDto();
         dto2.setId(2L);
         dto2.setTags(List.of("ECO_NEWS"));
-        dto2.setImage("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg");
+        dto2.setImage(IMG_EXAMPLE);
 
         PageableDto<HabitDto> pageableDto = new PageableDto<>(List.of(dto1, dto2), 1, 1, 2);
 
-        when(habitService.getAllByTagsAndLanguageCode(any(Pageable.class), eq(tags), eq(locale.getLanguage()))).thenReturn(pageableDto);
+        when(habitService.getAllByTagsAndLanguageCode(any(Pageable.class), eq(tags), eq(LOCALE.getLanguage()))).thenReturn(pageableDto);
 
-        mockMvc.perform(get(baseUrl + "/tags" + "/search")
+        mockMvc.perform(get(BASE_URL + "/tags/search")
                         .param("tags", "ECO_NEWS", "EVENT")
-                        .locale(locale)
+                        .header("Accept-Language", LOCALE.getLanguage())
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andReturn();
+                .andExpect(jsonPath("@.page[0].id").value(1L))
+                .andExpect(jsonPath("@.page[0].image").value(IMG_EXAMPLE))
+                .andExpect(jsonPath("@.page[0].tags").value("EVENT"));
 
-        verify(habitService).getAllByTagsAndLanguageCode(any(Pageable.class), eq(tags), eq(locale.getLanguage()));
+        verify(habitService).getAllByTagsAndLanguageCode(any(Pageable.class), eq(tags), eq(LOCALE.getLanguage()));
     }
 
     @Test
@@ -210,15 +223,16 @@ public class HabitControllerTest {
         List<String> tags = List.of("EVENT");
         Boolean isCustom = false;
         List<Integer> complexities = List.of(1);
+
         HabitDto dto1 = new HabitDto();
         dto1.setId(1L);
         dto1.setTags(List.of("EVENT"));
-        dto1.setImage("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg");
+        dto1.setImage(IMG_EXAMPLE);
 
         HabitDto dto2 = new HabitDto();
         dto2.setId(2L);
         dto2.setTags(List.of("ECO_NEWS"));
-        dto2.setImage("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg");
+        dto2.setImage(IMG_EXAMPLE);
 
         PageableDto<HabitDto> pageableDto = new PageableDto<>(List.of(dto1, dto2), 2, 0, 1);
 
@@ -228,18 +242,24 @@ public class HabitControllerTest {
                 eq(Optional.of(tags)),
                 eq(Optional.of(isCustom)),
                 eq(Optional.of(complexities)),
-                eq(locale.getLanguage()))).thenReturn(pageableDto);
+                eq(LOCALE.getLanguage()))).thenReturn(pageableDto);
 
-        mockMvc.perform(get(baseUrl + "/search")
+        mockMvc.perform(get(BASE_URL + "/search")
                         .param("tags", "EVENT")
                         .param("isCustomHabit", "false")
                         .param("complexities", "1")
-                        .locale(locale)
+                        .header("Accept-Language", LOCALE.getLanguage())
                         .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("@.page[0].id").value(1L))
+                .andExpect(jsonPath("@.page[0].image").value(IMG_EXAMPLE))
+                .andExpect(jsonPath("@.page[0].tags").value("EVENT"))
+                .andExpect(jsonPath("@.page[1].id").value(2L))
+                .andExpect(jsonPath("@.page[1].image").value(IMG_EXAMPLE))
+                .andExpect(jsonPath("@.page[1].tags").value("ECO_NEWS"));
 
         verify(habitService).getAllByDifferentParameters(any(UserVO.class), any(Pageable.class), eq(Optional.of(tags)),
-                eq(Optional.of(isCustom)), eq(Optional.of(complexities)), eq(locale.getLanguage()));
+                eq(Optional.of(isCustom)), eq(Optional.of(complexities)), eq(LOCALE.getLanguage()));
     }
 
     @Test
@@ -247,15 +267,16 @@ public class HabitControllerTest {
     void shouldReturnAllHabitTags() throws Exception {
         List<String> list = List.of("ECO_NEWS", "EVENT");
 
-        when(tagsService.findAllHabitsTags(locale.getLanguage())).thenReturn(list);
+        when(tagsService.findAllHabitsTags(LOCALE.getLanguage())).thenReturn(list);
 
-        mockMvc.perform(get(baseUrl + "/tags")
-                        .accept(locale.getLanguage())
+        mockMvc.perform(get(BASE_URL + "/tags")
+                        .header("Accept-Language", LOCALE.getLanguage())
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andReturn();
+                .andExpect(jsonPath("$[0]").value("ECO_NEWS"))
+                .andExpect(jsonPath("$[1]").value("EVENT"));
 
-        verify(tagsService).findAllHabitsTags(locale.getLanguage());
+        verify(tagsService).findAllHabitsTags(LOCALE.getLanguage());
     }
 
     @Test
@@ -275,21 +296,53 @@ public class HabitControllerTest {
 
         AddCustomHabitDtoResponse responseDto = new AddCustomHabitDtoResponse();
         responseDto.setId(1L);
-        responseDto.setImage("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg");
+        responseDto.setImage(IMG_EXAMPLE);
 
         when(habitService.addCustomHabit(any(), any(), eq("usergreencity@gmail.com"))).thenReturn(responseDto);
 
-        mockMvc.perform(multipart(baseUrl + "/custom")
+        mockMvc.perform(multipart(BASE_URL + "/custom")
                         .file(jsonPart)
                         .file(imagePart)
                         .with(csrf())
                         .principal(() -> "usergreencity@gmail.com")
+                        .header("Accept-Language", LOCALE.getLanguage())
                         .contentType(MediaType.MULTIPART_FORM_DATA)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value(1L))
-                .andExpect(jsonPath("$.image").value("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg"));
+                .andExpect(jsonPath("$.image").value(IMG_EXAMPLE));
 
         verify(habitService).addCustomHabit(any(), any(), eq("usergreencity@gmail.com"));
+    }
+
+    @Test
+    @DisplayName("GET /habit/{HABIT_ID}/friends/profile-pictures – should return profile pictures of friends assigned to habit")
+    void shouldReturnProfilePicturesOfFriendsAssignedToHabit() throws Exception {
+        List<UserProfilePictureDto> userProfilePictureDtos = List.of(
+                UserProfilePictureDto.builder()
+                        .id(1L)
+                        .name("Greg")
+                        .profilePicturePath(IMG_EXAMPLE)
+                        .build(),
+                UserProfilePictureDto.builder()
+                        .id(2L)
+                        .name("Dora")
+                        .profilePicturePath(IMG_EXAMPLE)
+                        .build());
+
+        when(habitService.getFriendsAssignedToHabitProfilePictures(eq(HABIT_ID), any())).thenReturn(userProfilePictureDtos);
+
+        mockMvc.perform(get(BASE_URL + "/{HABIT_ID}/friends/profile-pictures", HABIT_ID)
+                        .header("Accept-Language", LOCALE.getLanguage())
+                        .with(csrf())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].id").value(1L))
+                .andExpect(jsonPath("$[0].name").value("Greg"))
+                .andExpect(jsonPath("$[0].profilePicturePath").value(IMG_EXAMPLE))
+                .andExpect(jsonPath("$[1].id").value(2L))
+                .andExpect(jsonPath("$[1].name").value("Dora"))
+                .andExpect(jsonPath("$[1].profilePicturePath").value(IMG_EXAMPLE));
+
+        verify(habitService).getFriendsAssignedToHabitProfilePictures(eq(HABIT_ID), any());
     }
 }

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -90,13 +90,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 
 @ExtendWith(MockitoExtension.class)
-@WithMockUser(username = "usergreencity@gmail.com", roles = {"USER"})
+@WithMockUser(username = "usergreencity@gmail.com")
 public class HabitControllerTest {
 
     public static final String IMG_EXAMPLE = "https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg";
     private static final String BASE_URL = "/habit";
     private final Locale LOCALE = Locale.ENGLISH;
     private final Long HABIT_ID = 1L;
+
     @InjectMocks
     HabitController habitController;
     @Mock

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -6,6 +6,7 @@ import greencity.dto.habittranslation.HabitTranslationDto;
 import greencity.dto.shoppinglistitem.ShoppingListItemDto;
 import greencity.dto.user.UserVO;
 import greencity.service.HabitService;
+import greencity.service.TagsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -58,7 +60,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *          {@link HabitControllerTest#shouldReturnPageableDtoByTags()}
  *      </li>
  * </ul>
- * <ul>GET /habit/search – Filter habits by tags, isCustomHabit, complexities</ul>
+ * <ul>{@code GET /habit/search} – Filter habits by tags, isCustomHabit, complexities
+ *      <li>
+ *          {@link HabitControllerTest#shouldReturnPageWithSearchResult()}
+ *      </li>
+ * </ul>
  * <ul>GET /habit/tags – Get all habit tags</ul>
  * <ul>POST /habit/custom – Add new custom habit with multipart image</ul>
  * <ul>GET /habit/{habitId}/friends/profile-pictures – Get profile pictures of friends assigned to habit</ul>
@@ -74,6 +80,8 @@ public class HabitControllerTest {
     HabitController habitController;
     @Mock
     HabitService habitService;
+    @Mock
+    TagsService tagsService;
     private MockMvc mockMvc;
 
     @BeforeEach
@@ -221,4 +229,22 @@ public class HabitControllerTest {
         verify(habitService).getAllByDifferentParameters(any(UserVO.class), any(Pageable.class), eq(Optional.of(tags)),
                 eq(Optional.of(isCustom)), eq(Optional.of(complexities)), eq(locale.getLanguage()));
     }
+
+    @Test
+    @DisplayName("GET /habit/tags – should return all habit tags")
+    void shouldReturnAllHabitTags() throws Exception{
+        List<String> list = List.of("ECO_NEWS", "EVENT");
+
+        when(tagsService.findAllHabitsTags(locale.getLanguage())).thenReturn(list);
+
+        mockMvc.perform(get(baseUrl + "/tags")
+                .accept(locale.getLanguage())
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        verify(tagsService).findAllHabitsTags(locale.getLanguage());
+    }
+
+
 }

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -132,7 +132,7 @@ public class HabitControllerTest {
 
     @Test
     @DisplayName("GET /habit/{id} returns '400 - Bad Request' when passed wrong @id")
-    void shouldReturn404WhenPassedWrongId() throws Exception {
+    void shouldReturn400WhenPassedWrongId() throws Exception {
         String habitIdStr = "abc";
 
         mockMvc.perform(get(BASE_URL + "/{HABIT_ID}", habitIdStr)
@@ -336,6 +336,7 @@ public class HabitControllerTest {
                         .header("Accept-Language", LOCALE.getLanguage())
                         .with(csrf())
                         .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(1L))
                 .andExpect(jsonPath("$[0].name").value("Greg"))
                 .andExpect(jsonPath("$[0].profilePicturePath").value(IMG_EXAMPLE))

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -48,7 +48,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *      <li>
  *          {@link HabitControllerTest#shouldReturnExistingDtoWhenHabitIsFound()} ()}
  *      <li>
- *          {@link HabitControllerTest#shouldReturn404WhenPassedWrongId()}
+ *          {@link HabitControllerTest#shouldReturn400WhenPassedWrongId()}
  *      </li>
  * </ul>
  *

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -1,36 +1,61 @@
 package greencity.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import greencity.constant.ErrorMessage;
-import greencity.dto.genericresponse.GenericResponseDto;
+import com.azure.core.http.HttpResponse;
+import greencity.dto.PageableDto;
 import greencity.dto.habit.HabitDto;
 import greencity.dto.habittranslation.HabitTranslationDto;
+import greencity.dto.user.UserVO;
 import greencity.exception.exceptions.NotFoundException;
-import greencity.exception.handler.CustomExceptionHandler;
 import greencity.service.HabitService;
 import greencity.service.TagsService;
-import jakarta.persistence.EntityNotFoundException;
+import greencity.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
-import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
+import org.springframework.social.ResourceNotFoundException;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.util.List;
 import java.util.Locale;
 
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Unit test for {@link HabitController}.
+ *
+ * <p><b>Tested endpoints:</b></p>
+ *
+ * <ul>
+ *     {@code GET /habit/{id}} – Get habit by ID (localized)
+ *      <li>
+ *          {@link HabitControllerTest#findHabitByIdWithLocaleTranslation_whenHabitExists()}
+ *      <li>
+ *          {@link HabitControllerTest#findHabitByIdWithLocaleTranslation_whenHabitNotFound404()}
+ *      </li>
+ *      <li>
+ *          {@link HabitControllerTest#findHabitByIdWithLocaleTranslation_whenBadRequest400()}
+ *      </li>
+ * </ul>
+ *
+ * <ul>GET /habit – Get all habits for current user</ul>
+ * <ul>GET /habit/{id}/shopping-list – Get shopping list items for a habit</ul>
+ * <ul>GET /habit/tags/search – Get habits by tags and language code</ul>
+ * <ul>GET /habit/search – Filter habits by tags, isCustomHabit, complexities</ul>
+ * <ul>GET /habit/tags – Get all habit tags</ul>
+ * <ul>POST /habit/custom – Add new custom habit with multipart image</ul>
+ * <ul>GET /habit/{habitId}/friends/profile-pictures – Get profile pictures of friends assigned to habit</ul>
+ */
 
 @ExtendWith(MockitoExtension.class)
 public class HabitControllerTest {
@@ -40,21 +65,20 @@ public class HabitControllerTest {
     HabitController habitController;
     @Mock
     HabitService habitService;
+    @Mock
+    UserService userService;
     @MockBean
     TagsService tagsService;
     private MockMvc mockMvc;
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
     void setup() {
-        ErrorAttributes errorAttributes = new DefaultErrorAttributes();
-
         this.mockMvc = MockMvcBuilders.standaloneSetup(habitController)
-            .setControllerAdvice(new CustomExceptionHandler(errorAttributes, objectMapper))
-            .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver()).build();
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver()).build();
     }
 
     @Test
+    @DisplayName("GET /habit/{id} returns existing DTO when habit is found")
     void findHabitByIdWithLocaleTranslation_whenHabitExists() throws Exception {
         Long habitId = 1L;
         Locale locale = Locale.ENGLISH;
@@ -65,31 +89,77 @@ public class HabitControllerTest {
         when(habitService.getByIdAndLanguageCode(habitId, locale.getLanguage())).thenReturn(expectedHabitDto);
 
         mockMvc.perform(get(baseUrl + "/" + habitId)
-            .locale(locale)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.habitTranslation.languageCode").value(locale.getLanguage()))
-            .andExpect(jsonPath("$.id").value(habitId));
+                        .locale(locale)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.habitTranslation.languageCode").value(locale.getLanguage()))
+                .andExpect(jsonPath("$.id").value(habitId));
 
         verify(habitService).getByIdAndLanguageCode(habitId, locale.getLanguage());
 
     }
 
     @Test
+    @DisplayName("GET /habit/{id} returns '404 - Not Found' when habit is not found")
     void findHabitByIdWithLocaleTranslation_whenHabitNotFound404() throws Exception {
         Long habitId = 1L;
         Locale locale = Locale.ENGLISH;
-        String errorMessage = ErrorMessage.HABIT_NOT_FOUND_BY_ID + habitId;
 
         when(habitService.getByIdAndLanguageCode(habitId, locale.getLanguage()))
-            .thenThrow(NotFoundException.class);
+                .thenThrow(NotFoundException.class);
 
         mockMvc.perform(get(baseUrl + "/" + habitId)
-            .locale(locale)
-            .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isNotFound());
+                        .locale(locale)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
 
         verify(habitService).getByIdAndLanguageCode(habitId, locale.getLanguage());
+    }
+
+    @Test
+    @DisplayName("GET /habit/{id} returns '400 - Bad Request' when passed wrong @id")
+    void findHabitByIdWithLocaleTranslation_whenBadRequest400() throws Exception {
+        String habitId = "abc";
+        Locale locale = Locale.ENGLISH;
+
+        mockMvc.perform(get(baseUrl + "/" + habitId)
+                        .locale(locale)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(habitService);
+    }
+
+    @Test
+    @DisplayName("GET /habit returns all default and custom habits")
+    void shouldReturnPageableDtoOfHabitDto_whenFindAllHabitsCalled() throws Exception {
+
+        Locale locale = Locale.ENGLISH;
+        List<HabitDto> habits = List.of(new HabitDto().setImage("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg"));
+        PageableDto<HabitDto> page = new PageableDto<>(habits, 1, 0, 1);
+        when(habitService.getAllHabitsByLanguageCode(any(UserVO.class), any(Pageable.class), eq(locale.getLanguage()))).thenReturn(page);
+
+         mockMvc.perform(get(baseUrl)
+                         .accept(MediaType.APPLICATION_JSON))
+                 .andExpect(status().isOk())
+                 .andExpect(jsonPath("@.page[0].image").value("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg"));
+
+         verify(habitService).getAllHabitsByLanguageCode(any(UserVO.class), any(Pageable.class), eq(locale.getLanguage()));
+    }
+
+    @Test
+    @DisplayName("GET /habit returns '400 - Bad Request' when no habits found")
+    void shouldReturnPageableDtoOfHabitDto_whenNoHabitsFound() throws Exception {
+        Locale locale = Locale.ENGLISH;
+        List<HabitDto> habits = List.of();
+        PageableDto<HabitDto> page = new PageableDto<>(habits, 1, 0, 1);
+
+        when(habitService.getAllHabitsByLanguageCode(any(UserVO.class), any(Pageable.class), eq(locale.getLanguage()))).thenReturn(page);
+
+        mockMvc.perform(get(baseUrl)
+                .locale(locale)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
     }
 
 }

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -1,0 +1,66 @@
+package greencity.controller;
+
+import greencity.dto.habit.HabitDto;
+import greencity.dto.habittranslation.HabitTranslationDto;
+import greencity.service.HabitService;
+import greencity.service.TagsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Locale;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@ExtendWith(MockitoExtension.class)
+public class HabitControllerTest {
+
+    private static final String baseUrl = "/habit";
+    @InjectMocks
+    HabitController habitController;
+    @Mock
+    HabitService habitService;
+    @MockBean
+    TagsService tagsService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setup() {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(habitController).setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver()).build();
+    }
+
+    @Test
+    void findHabitByIdWithLocaleTranslation_whenHabitExists() throws Exception {
+        Long habitId = 1L;
+        Locale locale = Locale.ENGLISH;
+        HabitDto expectedHabitDto = new HabitDto();
+        expectedHabitDto.setId(habitId);
+        expectedHabitDto.setHabitTranslation(new HabitTranslationDto().setLanguageCode(locale.getLanguage()));
+
+        when(habitService.getByIdAndLanguageCode(habitId, locale.getLanguage())).thenReturn(expectedHabitDto);
+
+        mockMvc.perform(get(baseUrl + "/" + habitId)
+                .locale(locale)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.habitTranslation.languageCode").value(locale.getLanguage()))
+                .andExpect(jsonPath("$.id").value(habitId));
+
+        verify(habitService).getByIdAndLanguageCode(habitId, locale.getLanguage());
+
+    }
+
+}

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -1,6 +1,9 @@
 package greencity.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import greencity.dto.PageableDto;
+import greencity.dto.habit.AddCustomHabitDtoRequest;
+import greencity.dto.habit.AddCustomHabitDtoResponse;
 import greencity.dto.habit.HabitDto;
 import greencity.dto.habittranslation.HabitTranslationDto;
 import greencity.dto.shoppinglistitem.ShoppingListItemDto;
@@ -17,7 +20,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -25,9 +29,12 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -65,12 +72,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *          {@link HabitControllerTest#shouldReturnPageWithSearchResult()}
  *      </li>
  * </ul>
- * <ul>GET /habit/tags – Get all habit tags</ul>
+ * <ul>{@code GET /habit/tags} – Get all habit tags
+ *      <li>
+ *          {@link HabitControllerTest#shouldReturnAllHabitTags()}
+ *      </li>
+ * </ul>
  * <ul>POST /habit/custom – Add new custom habit with multipart image</ul>
  * <ul>GET /habit/{habitId}/friends/profile-pictures – Get profile pictures of friends assigned to habit</ul>
  */
 
 @ExtendWith(MockitoExtension.class)
+@WithMockUser(username = "usergreencity@gmail.com", roles = {"USER"})
 public class HabitControllerTest {
 
     private static final String baseUrl = "/habit";
@@ -194,7 +206,7 @@ public class HabitControllerTest {
 
     @Test
     @DisplayName("GET /habit/search – Filter habits by tags, isCustomHabit, complexities")
-    void shouldReturnPageWithSearchResult() throws Exception{
+    void shouldReturnPageWithSearchResult() throws Exception {
         List<String> tags = List.of("EVENT");
         Boolean isCustom = false;
         List<Integer> complexities = List.of(1);
@@ -208,7 +220,7 @@ public class HabitControllerTest {
         dto2.setTags(List.of("ECO_NEWS"));
         dto2.setImage("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg");
 
-        PageableDto<HabitDto> pageableDto = new PageableDto<>(List.of(dto1, dto2), 2, 0,1);
+        PageableDto<HabitDto> pageableDto = new PageableDto<>(List.of(dto1, dto2), 2, 0, 1);
 
         when(habitService.getAllByDifferentParameters(
                 any(UserVO.class),
@@ -219,11 +231,11 @@ public class HabitControllerTest {
                 eq(locale.getLanguage()))).thenReturn(pageableDto);
 
         mockMvc.perform(get(baseUrl + "/search")
-                .param("tags", "EVENT")
-                .param("isCustomHabit", "false")
-                .param("complexities", "1")
-                .locale(locale)
-                .accept(MediaType.APPLICATION_JSON))
+                        .param("tags", "EVENT")
+                        .param("isCustomHabit", "false")
+                        .param("complexities", "1")
+                        .locale(locale)
+                        .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
         verify(habitService).getAllByDifferentParameters(any(UserVO.class), any(Pageable.class), eq(Optional.of(tags)),
@@ -232,19 +244,52 @@ public class HabitControllerTest {
 
     @Test
     @DisplayName("GET /habit/tags – should return all habit tags")
-    void shouldReturnAllHabitTags() throws Exception{
+    void shouldReturnAllHabitTags() throws Exception {
         List<String> list = List.of("ECO_NEWS", "EVENT");
 
         when(tagsService.findAllHabitsTags(locale.getLanguage())).thenReturn(list);
 
         mockMvc.perform(get(baseUrl + "/tags")
-                .accept(locale.getLanguage())
-                .accept(MediaType.APPLICATION_JSON))
+                        .accept(locale.getLanguage())
+                        .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andReturn();
 
         verify(tagsService).findAllHabitsTags(locale.getLanguage());
     }
 
+    @Test
+    @DisplayName("POST /habit/custom – should add new custom habit with multipart image")
+    void shouldAddNewCustomHabitWithMultipartImage() throws Exception {
+        AddCustomHabitDtoRequest requestDto = new AddCustomHabitDtoRequest();
+        requestDto.setTagIds(Set.of(1L, 2L));
+        requestDto.setComplexity(1);
+        requestDto.setHabitTranslations(List.of(new HabitTranslationDto()));
 
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonRequest = objectMapper.writeValueAsString(requestDto);
+
+        MockMultipartFile jsonPart = new MockMultipartFile("request", "", "application/json", jsonRequest.getBytes());
+
+        MockMultipartFile imagePart = new MockMultipartFile("image", "image.jpg", MediaType.IMAGE_JPEG_VALUE, "image-bytes".getBytes());
+
+        AddCustomHabitDtoResponse responseDto = new AddCustomHabitDtoResponse();
+        responseDto.setId(1L);
+        responseDto.setImage("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg");
+
+        when(habitService.addCustomHabit(any(), any(), eq("usergreencity@gmail.com"))).thenReturn(responseDto);
+
+        mockMvc.perform(multipart(baseUrl + "/custom")
+                        .file(jsonPart)
+                        .file(imagePart)
+                        .with(csrf())
+                        .principal(() -> "usergreencity@gmail.com")
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.image").value("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg"));
+
+        verify(habitService).addCustomHabit(any(), any(), eq("usergreencity@gmail.com"));
+    }
 }

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -97,6 +97,7 @@ public class HabitControllerTest {
     private static final String BASE_URL = "/habit";
     private final Locale LOCALE = Locale.ENGLISH;
     private final Long HABIT_ID = 1L;
+
     @InjectMocks
     HabitController habitController;
     @Mock

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -1,9 +1,15 @@
 package greencity.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import greencity.constant.ErrorMessage;
+import greencity.dto.genericresponse.GenericResponseDto;
 import greencity.dto.habit.HabitDto;
 import greencity.dto.habittranslation.HabitTranslationDto;
+import greencity.exception.exceptions.NotFoundException;
+import greencity.exception.handler.CustomExceptionHandler;
 import greencity.service.HabitService;
 import greencity.service.TagsService;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,6 +17,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.servlet.error.DefaultErrorAttributes;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -24,7 +32,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-
 @ExtendWith(MockitoExtension.class)
 public class HabitControllerTest {
 
@@ -36,10 +43,15 @@ public class HabitControllerTest {
     @MockBean
     TagsService tagsService;
     private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
     void setup() {
-        this.mockMvc = MockMvcBuilders.standaloneSetup(habitController).setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver()).build();
+        ErrorAttributes errorAttributes = new DefaultErrorAttributes();
+
+        this.mockMvc = MockMvcBuilders.standaloneSetup(habitController)
+            .setControllerAdvice(new CustomExceptionHandler(errorAttributes, objectMapper))
+            .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver()).build();
     }
 
     @Test
@@ -53,14 +65,31 @@ public class HabitControllerTest {
         when(habitService.getByIdAndLanguageCode(habitId, locale.getLanguage())).thenReturn(expectedHabitDto);
 
         mockMvc.perform(get(baseUrl + "/" + habitId)
-                .locale(locale)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.habitTranslation.languageCode").value(locale.getLanguage()))
-                .andExpect(jsonPath("$.id").value(habitId));
+            .locale(locale)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.habitTranslation.languageCode").value(locale.getLanguage()))
+            .andExpect(jsonPath("$.id").value(habitId));
 
         verify(habitService).getByIdAndLanguageCode(habitId, locale.getLanguage());
 
+    }
+
+    @Test
+    void findHabitByIdWithLocaleTranslation_whenHabitNotFound404() throws Exception {
+        Long habitId = 1L;
+        Locale locale = Locale.ENGLISH;
+        String errorMessage = ErrorMessage.HABIT_NOT_FOUND_BY_ID + habitId;
+
+        when(habitService.getByIdAndLanguageCode(habitId, locale.getLanguage()))
+            .thenThrow(NotFoundException.class);
+
+        mockMvc.perform(get(baseUrl + "/" + habitId)
+            .locale(locale)
+            .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+
+        verify(habitService).getByIdAndLanguageCode(habitId, locale.getLanguage());
     }
 
 }

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -1,14 +1,12 @@
 package greencity.controller;
 
-import com.azure.core.http.HttpResponse;
 import greencity.dto.PageableDto;
 import greencity.dto.habit.HabitDto;
 import greencity.dto.habittranslation.HabitTranslationDto;
+import greencity.dto.shoppinglistitem.ShoppingListItemDto;
 import greencity.dto.user.UserVO;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.service.HabitService;
-import greencity.service.TagsService;
-import greencity.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,11 +14,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
-import org.springframework.social.ResourceNotFoundException;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -29,7 +26,8 @@ import java.util.Locale;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * Unit test for {@link HabitController}.
@@ -48,8 +46,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *      </li>
  * </ul>
  *
- * <ul>GET /habit – Get all habits for current user</ul>
- * <ul>GET /habit/{id}/shopping-list – Get shopping list items for a habit</ul>
+ * <ul>{@code GET /habit} – Get all habits for current user
+ *      <li>
+ *          {@link HabitControllerTest#shouldReturnPageableDtoOfHabitDto()}
+ *      </li>
+ * </ul>
+ * <ul>{@code GET /habit/{id}/shopping-list} – Get shopping list items for a habit
+ *      <li>
+ *          {@link HabitControllerTest#shouldReturnShoppingListItemDto()}
+ *      </li>
+ * </ul>
  * <ul>GET /habit/tags/search – Get habits by tags and language code</ul>
  * <ul>GET /habit/search – Filter habits by tags, isCustomHabit, complexities</ul>
  * <ul>GET /habit/tags – Get all habit tags</ul>
@@ -66,9 +72,7 @@ public class HabitControllerTest {
     @Mock
     HabitService habitService;
     @Mock
-    UserService userService;
-    @MockBean
-    TagsService tagsService;
+    ModelMapper modelMapper;
     private MockMvc mockMvc;
 
     @BeforeEach
@@ -132,34 +136,48 @@ public class HabitControllerTest {
 
     @Test
     @DisplayName("GET /habit returns all default and custom habits")
-    void shouldReturnPageableDtoOfHabitDto_whenFindAllHabitsCalled() throws Exception {
+    void shouldReturnPageableDtoOfHabitDto() throws Exception {
 
         Locale locale = Locale.ENGLISH;
         List<HabitDto> habits = List.of(new HabitDto().setImage("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg"));
         PageableDto<HabitDto> page = new PageableDto<>(habits, 1, 0, 1);
         when(habitService.getAllHabitsByLanguageCode(any(UserVO.class), any(Pageable.class), eq(locale.getLanguage()))).thenReturn(page);
 
-         mockMvc.perform(get(baseUrl)
-                         .accept(MediaType.APPLICATION_JSON))
-                 .andExpect(status().isOk())
-                 .andExpect(jsonPath("@.page[0].image").value("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg"));
+        mockMvc.perform(get(baseUrl)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("@.page[0].image").value("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg"));
 
-         verify(habitService).getAllHabitsByLanguageCode(any(UserVO.class), any(Pageable.class), eq(locale.getLanguage()));
+        verify(habitService).getAllHabitsByLanguageCode(any(UserVO.class), any(Pageable.class), eq(locale.getLanguage()));
     }
 
     @Test
-    @DisplayName("GET /habit returns '400 - Bad Request' when no habits found")
-    void shouldReturnPageableDtoOfHabitDto_whenNoHabitsFound() throws Exception {
+    @DisplayName("GET /habit/{id}/shopping-list should return array of 'ShoppingListItemDto'")
+    void shouldReturnShoppingListItemDto() throws Exception {
         Locale locale = Locale.ENGLISH;
-        List<HabitDto> habits = List.of();
-        PageableDto<HabitDto> page = new PageableDto<>(habits, 1, 0, 1);
+        Long habitId = 1L;
 
-        when(habitService.getAllHabitsByLanguageCode(any(UserVO.class), any(Pageable.class), eq(locale.getLanguage()))).thenReturn(page);
+        ShoppingListItemDto dto1 = new ShoppingListItemDto();
+        dto1.setId(10L);
+        dto1.setText("Reusable bag");
 
-        mockMvc.perform(get(baseUrl)
-                .locale(locale)
-                .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
+        ShoppingListItemDto dto2 = new ShoppingListItemDto();
+        dto2.setId(11L);
+        dto2.setText("Glass bottle");
+
+        when(habitService.getShoppingListForHabit(habitId, locale.getLanguage()))
+                .thenReturn(List.of(dto1, dto2));
+
+        mockMvc.perform(get(baseUrl + "/" + habitId + "/shopping-list")
+                        .locale(locale)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(10L))
+                .andExpect(jsonPath("$[0].text").value("Reusable bag"))
+                .andExpect(jsonPath("$[1].id").value(11L))
+                .andExpect(jsonPath("$[1].text").value("Glass bottle"));
+
+        verify(habitService).getShoppingListForHabit(habitId, locale.getLanguage());
     }
 
 }

--- a/core/src/test/java/greencity/controller/HabitControllerTest.java
+++ b/core/src/test/java/greencity/controller/HabitControllerTest.java
@@ -5,7 +5,6 @@ import greencity.dto.habit.HabitDto;
 import greencity.dto.habittranslation.HabitTranslationDto;
 import greencity.dto.shoppinglistitem.ShoppingListItemDto;
 import greencity.dto.user.UserVO;
-import greencity.exception.exceptions.NotFoundException;
 import greencity.service.HabitService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,15 +13,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -39,9 +39,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *      <li>
  *          {@link HabitControllerTest#findHabitByIdWithLocaleTranslation_whenHabitExists()}
  *      <li>
- *          {@link HabitControllerTest#findHabitByIdWithLocaleTranslation_whenHabitNotFound404()}
- *      </li>
- *      <li>
  *          {@link HabitControllerTest#findHabitByIdWithLocaleTranslation_whenBadRequest400()}
  *      </li>
  * </ul>
@@ -56,7 +53,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *          {@link HabitControllerTest#shouldReturnShoppingListItemDto()}
  *      </li>
  * </ul>
- * <ul>GET /habit/tags/search – Get habits by tags and language code</ul>
+ * <ul>{@code GET /habit/tags/search} – Get habits by tags and language code
+ *      <li>
+ *          {@link HabitControllerTest#shouldReturnPageableDtoByTags()}
+ *      </li>
+ * </ul>
  * <ul>GET /habit/search – Filter habits by tags, isCustomHabit, complexities</ul>
  * <ul>GET /habit/tags – Get all habit tags</ul>
  * <ul>POST /habit/custom – Add new custom habit with multipart image</ul>
@@ -67,12 +68,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class HabitControllerTest {
 
     private static final String baseUrl = "/habit";
+    private final Locale locale = Locale.ENGLISH;
+    private final Long habitId = 1L;
     @InjectMocks
     HabitController habitController;
     @Mock
     HabitService habitService;
-    @Mock
-    ModelMapper modelMapper;
     private MockMvc mockMvc;
 
     @BeforeEach
@@ -84,8 +85,6 @@ public class HabitControllerTest {
     @Test
     @DisplayName("GET /habit/{id} returns existing DTO when habit is found")
     void findHabitByIdWithLocaleTranslation_whenHabitExists() throws Exception {
-        Long habitId = 1L;
-        Locale locale = Locale.ENGLISH;
         HabitDto expectedHabitDto = new HabitDto();
         expectedHabitDto.setId(habitId);
         expectedHabitDto.setHabitTranslation(new HabitTranslationDto().setLanguageCode(locale.getLanguage()));
@@ -104,28 +103,9 @@ public class HabitControllerTest {
     }
 
     @Test
-    @DisplayName("GET /habit/{id} returns '404 - Not Found' when habit is not found")
-    void findHabitByIdWithLocaleTranslation_whenHabitNotFound404() throws Exception {
-        Long habitId = 1L;
-        Locale locale = Locale.ENGLISH;
-
-        when(habitService.getByIdAndLanguageCode(habitId, locale.getLanguage()))
-                .thenThrow(NotFoundException.class);
-
-        mockMvc.perform(get(baseUrl + "/" + habitId)
-                        .locale(locale)
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound());
-
-        verify(habitService).getByIdAndLanguageCode(habitId, locale.getLanguage());
-    }
-
-    @Test
     @DisplayName("GET /habit/{id} returns '400 - Bad Request' when passed wrong @id")
     void findHabitByIdWithLocaleTranslation_whenBadRequest400() throws Exception {
         String habitId = "abc";
-        Locale locale = Locale.ENGLISH;
-
         mockMvc.perform(get(baseUrl + "/" + habitId)
                         .locale(locale)
                         .accept(MediaType.APPLICATION_JSON))
@@ -137,8 +117,6 @@ public class HabitControllerTest {
     @Test
     @DisplayName("GET /habit returns all default and custom habits")
     void shouldReturnPageableDtoOfHabitDto() throws Exception {
-
-        Locale locale = Locale.ENGLISH;
         List<HabitDto> habits = List.of(new HabitDto().setImage("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg"));
         PageableDto<HabitDto> page = new PageableDto<>(habits, 1, 0, 1);
         when(habitService.getAllHabitsByLanguageCode(any(UserVO.class), any(Pageable.class), eq(locale.getLanguage()))).thenReturn(page);
@@ -154,9 +132,6 @@ public class HabitControllerTest {
     @Test
     @DisplayName("GET /habit/{id}/shopping-list should return array of 'ShoppingListItemDto'")
     void shouldReturnShoppingListItemDto() throws Exception {
-        Locale locale = Locale.ENGLISH;
-        Long habitId = 1L;
-
         ShoppingListItemDto dto1 = new ShoppingListItemDto();
         dto1.setId(10L);
         dto1.setText("Reusable bag");
@@ -180,4 +155,70 @@ public class HabitControllerTest {
         verify(habitService).getShoppingListForHabit(habitId, locale.getLanguage());
     }
 
+    @Test
+    @DisplayName("GET /habit/tags/search should return PageableDto")
+    void shouldReturnPageableDtoByTags() throws Exception {
+        List<String> tags = List.of("ECO_NEWS", "EVENT");
+
+        HabitDto dto1 = new HabitDto();
+        dto1.setId(1L);
+        dto1.setTags(List.of("EVENT"));
+        dto1.setImage("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg");
+
+        HabitDto dto2 = new HabitDto();
+        dto2.setId(2L);
+        dto2.setTags(List.of("ECO_NEWS"));
+        dto2.setImage("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg");
+
+        PageableDto<HabitDto> pageableDto = new PageableDto<>(List.of(dto1, dto2), 1, 1, 2);
+
+        when(habitService.getAllByTagsAndLanguageCode(any(Pageable.class), eq(tags), eq(locale.getLanguage()))).thenReturn(pageableDto);
+
+        mockMvc.perform(get(baseUrl + "/tags" + "/search")
+                        .param("tags", "ECO_NEWS", "EVENT")
+                        .locale(locale)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        verify(habitService).getAllByTagsAndLanguageCode(any(Pageable.class), eq(tags), eq(locale.getLanguage()));
+    }
+
+    @Test
+    @DisplayName("GET /habit/search – Filter habits by tags, isCustomHabit, complexities")
+    void shouldReturnPageWithSearchResult() throws Exception{
+        List<String> tags = List.of("EVENT");
+        Boolean isCustom = false;
+        List<Integer> complexities = List.of(1);
+        HabitDto dto1 = new HabitDto();
+        dto1.setId(1L);
+        dto1.setTags(List.of("EVENT"));
+        dto1.setImage("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg");
+
+        HabitDto dto2 = new HabitDto();
+        dto2.setId(2L);
+        dto2.setTags(List.of("ECO_NEWS"));
+        dto2.setImage("https://csb10032000a548f571.blob.core.windows.net/allfiles/304ff73c-7e6d-4a17-be7d-59fc3666d351931fb71c088a926a1e04b6896d109fa2.jpg");
+
+        PageableDto<HabitDto> pageableDto = new PageableDto<>(List.of(dto1, dto2), 2, 0,1);
+
+        when(habitService.getAllByDifferentParameters(
+                any(UserVO.class),
+                any(Pageable.class),
+                eq(Optional.of(tags)),
+                eq(Optional.of(isCustom)),
+                eq(Optional.of(complexities)),
+                eq(locale.getLanguage()))).thenReturn(pageableDto);
+
+        mockMvc.perform(get(baseUrl + "/search")
+                .param("tags", "EVENT")
+                .param("isCustomHabit", "false")
+                .param("complexities", "1")
+                .locale(locale)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(habitService).getAllByDifferentParameters(any(UserVO.class), any(Pageable.class), eq(Optional.of(tags)),
+                eq(Optional.of(isCustom)), eq(Optional.of(complexities)), eq(locale.getLanguage()));
+    }
 }


### PR DESCRIPTION
Implemented test for HabitController.java for the next enpoints:
-     GET /habit/{id} – Get habit by ID (localized)
-     GET /habit – Get all habits for current user
-     GET /habit/{id}/shopping-list – Get shopping list items for a habit
-     GET /habit/tags/search – Get habits by tags and language code
-     GET /habit/search – Filter habits by tags, isCustomHabit, complexities
-     GET /habit/tags – Get all habit tags
-     POST /habit/custom – Add new custom habit with multipart image
-     GET /habit/{habitId}/friends/profile-pictures – Get profile pictures of friends assigned to habit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive set of unit tests for habit-related REST API endpoints, including retrieval, filtering, creation, and validation of habits and associated data.
  * Tests cover various scenarios such as localization, pagination, multipart form submissions, and error handling to ensure robust API behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->