### PR TITLE
Return Forbidden when deleting other user's EcoNews

### DIFF
--- a/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
@@ -18,10 +18,7 @@ import greencity.entity.*;
 import greencity.entity.localization.TagTranslation;
 import greencity.enums.Role;
 import greencity.enums.TagType;
-import greencity.exception.exceptions.BadRequestException;
-import greencity.exception.exceptions.NotFoundException;
-import greencity.exception.exceptions.NotSavedException;
-import greencity.exception.exceptions.UnsupportedSortException;
+import greencity.exception.exceptions.*;
 import greencity.filters.EcoNewsSpecification;
 import greencity.filters.SearchCriteria;
 import greencity.repository.EcoNewsRepo;
@@ -317,7 +314,7 @@ public class EcoNewsServiceImpl implements EcoNewsService {
     public void delete(Long id, UserVO user) {
         EcoNewsVO ecoNewsVO = findById(id);
         if (user.getRole() != Role.ROLE_ADMIN && !user.getId().equals(ecoNewsVO.getAuthor().getId())) {
-            throw new BadRequestException(ErrorMessage.USER_HAS_NO_PERMISSION);
+            throw new UserHasNoPermissionToAccessException(ErrorMessage.USER_HAS_NO_PERMISSION);
         }
         String accessToken = httpServletRequest.getHeader(AUTHORIZATION);
         CompletableFuture.runAsync(

--- a/service/src/test/java/greencity/service/EcoNewsServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EcoNewsServiceImplTest.java
@@ -16,10 +16,7 @@ import greencity.entity.EcoNews;
 import greencity.entity.Tag;
 import greencity.entity.User;
 import greencity.enums.TagType;
-import greencity.exception.exceptions.BadRequestException;
-import greencity.exception.exceptions.NotFoundException;
-import greencity.exception.exceptions.NotSavedException;
-import greencity.exception.exceptions.UnsupportedSortException;
+import greencity.exception.exceptions.*;
 import greencity.filters.EcoNewsSpecification;
 import greencity.filters.SearchCriteria;
 import greencity.repository.EcoNewsRepo;
@@ -364,7 +361,7 @@ class EcoNewsServiceImplTest {
         when(ecoNewsRepo.findById(1L)).thenReturn(Optional.of(ecoNews));
         when(modelMapper.map(ecoNews, EcoNewsVO.class)).thenReturn(ecoNewsVO);
         ecoNewsVO.setAuthor(author);
-        assertThrows(BadRequestException.class, () -> ecoNewsService.delete(1L, userVO));
+        assertThrows(UserHasNoPermissionToAccessException.class, () -> ecoNewsService.delete(1L, userVO));
     }
 
     @Test


### PR DESCRIPTION
Closes GreenCity-UA-4146-4625-01/Issues#71.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling by displaying a more accurate message when users lack permission to delete news items.

* **Tests**
  * Updated tests to check for the correct permission-related error when attempting unauthorized deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->