### PR TITLE
 Notification controller & security  

### DIFF
--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -90,6 +90,7 @@ public final class ErrorMessage {
     public static final String CUSTOM_SHOPPING_LIST_ITEM_NOT_FOUND =
         "The user doesn't have any custom shopping list item.";
     public static final String USER_HAS_NO_PERMISSION = "Current user has no permission for this action";
+    public static final String ACCESS_DENIED_NOTIFICATION = "Access denied to this notification.";
     public static final String ECO_NEWS_NOT_FOUND_BY_ID = "Eco news doesn't exist by this id: ";
     public static final String ECO_NEWS_NOT_FOUND = "Eco news haven't been found";
     public static final String ECO_NEWS_NOT_SAVED = "Eco news haven't been saved because of constraint violation";

--- a/service/src/main/java/greencity/controller/NotificationController.java
+++ b/service/src/main/java/greencity/controller/NotificationController.java
@@ -1,0 +1,69 @@
+package greencity.controller;
+
+
+import greencity.dto.notification.NotificationDto;
+import greencity.entity.Notification;
+import greencity.service.NotificationService;
+import greencity.service.UserService;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationService notificationService;
+    private final UserService userService;
+
+    /** Отримати всі нотифікації поточного користувача. */
+    @GetMapping
+    public ResponseEntity<List<NotificationDto>> getNotifications(Principal principal) {
+        Long userId = getCurrentUserId(principal);
+        return ResponseEntity.ok(notificationService.getAllNotificationsForUser(userId));
+    }
+
+    /** одну нотифікацію як прочитану. */
+    @PostMapping("/{id}/markAsRead")
+    public ResponseEntity<Void> markAsRead(@PathVariable Long id, Principal principal) {
+        Long userId = getCurrentUserId(principal);
+        ensureNotificationBelongsToUser(id, userId);
+        notificationService.markAsRead(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /** всі нотифікації користувача як прочитані. */
+    @PostMapping("/markAllAsRead")
+    public ResponseEntity<Void> markAllAsRead(Principal principal) {
+        notificationService.markAllAsRead(getCurrentUserId(principal));
+        return ResponseEntity.noContent().build();
+    }
+
+    /** список нотифікацій як прочитані. */
+    @PostMapping("/markAsReadBulk")
+    public ResponseEntity<Void> markAsReadBulk(@RequestBody @NotEmpty List<Long> ids,
+                                               Principal principal) {
+        Long userId = getCurrentUserId(principal);
+        ids.forEach(id -> ensureNotificationBelongsToUser(id, userId));
+        notificationService.markAsReadBulk(ids);
+        return ResponseEntity.noContent().build();
+    }
+
+
+    private Long getCurrentUserId(Principal principal) {
+        return userService.findByEmail(principal.getName()).getId();
+    }
+
+    private void ensureNotificationBelongsToUser(Long notificationId, Long userId) {
+        Notification n = notificationService.findById(notificationId);
+        if (!n.getReceiver().getId().equals(userId)) {
+            throw new AccessDeniedException("Access denied to this notification.");
+        }
+    }
+}
+

--- a/service/src/main/java/greencity/controller/NotificationController.java
+++ b/service/src/main/java/greencity/controller/NotificationController.java
@@ -1,6 +1,6 @@
 package greencity.controller;
 
-
+import greencity.constant.ErrorMessage;
 import greencity.dto.notification.NotificationDto;
 import greencity.entity.Notification;
 import greencity.service.NotificationService;
@@ -21,49 +21,49 @@ public class NotificationController {
     private final NotificationService notificationService;
     private final UserService userService;
 
-    /** Отримати всі нотифікації поточного користувача. */
+    /** Get all notifications for the current user. */
     @GetMapping
     public ResponseEntity<List<NotificationDto>> getNotifications(Principal principal) {
-        Long userId = getCurrentUserId(principal);
+        Long userId = currentUserId(principal);
         return ResponseEntity.ok(notificationService.getAllNotificationsForUser(userId));
     }
 
-    /** одну нотифікацію як прочитану. */
+    /** Mark a single notification as read. */
     @PostMapping("/{id}/markAsRead")
     public ResponseEntity<Void> markAsRead(@PathVariable Long id, Principal principal) {
-        Long userId = getCurrentUserId(principal);
-        ensureNotificationBelongsToUser(id, userId);
+        Long userId = currentUserId(principal);
+        ensureOwner(id, userId);
         notificationService.markAsRead(id);
         return ResponseEntity.noContent().build();
     }
 
-    /** всі нотифікації користувача як прочитані. */
+    /** Mark all notifications of the current user as read. */
     @PostMapping("/markAllAsRead")
     public ResponseEntity<Void> markAllAsRead(Principal principal) {
-        notificationService.markAllAsRead(getCurrentUserId(principal));
+        notificationService.markAllAsRead(currentUserId(principal));
         return ResponseEntity.noContent().build();
     }
 
-    /** список нотифікацій як прочитані. */
+    /** Mark a list of notifications as read (bulk). */
     @PostMapping("/markAsReadBulk")
     public ResponseEntity<Void> markAsReadBulk(@RequestBody @NotEmpty List<Long> ids,
                                                Principal principal) {
-        Long userId = getCurrentUserId(principal);
-        ids.forEach(id -> ensureNotificationBelongsToUser(id, userId));
+        Long userId = currentUserId(principal);
+        ids.forEach(id -> ensureOwner(id, userId));
         notificationService.markAsReadBulk(ids);
         return ResponseEntity.noContent().build();
     }
 
 
-    private Long getCurrentUserId(Principal principal) {
+    private Long currentUserId(Principal principal) {
         return userService.findByEmail(principal.getName()).getId();
     }
 
-    private void ensureNotificationBelongsToUser(Long notificationId, Long userId) {
+    /** Throws 403 if the notification does not belong to the current user. */
+    private void ensureOwner(Long notificationId, Long userId) {
         Notification n = notificationService.findById(notificationId);
         if (!n.getReceiver().getId().equals(userId)) {
-            throw new AccessDeniedException("Access denied to this notification.");
+            throw new AccessDeniedException(ErrorMessage.ACCESS_DENIED_NOTIFICATION);
         }
     }
 }
-


### PR DESCRIPTION
What’s included
* Added `NotificationController` — initial implementation for issues #179, #181,#182, #183
   `GET /notifications` – returns the user’s notifications  
   `POST /notifications/{id}/markAsRead`  
   `POST /notifications/markAllAsRead`  
   `POST /notifications/markAsReadBulk`
**Draft version**:only the basic.