### PR TITLE
New endpoint search events implemented

### DIFF
--- a/core/src/main/java/greencity/constant/ValidationConstants.java
+++ b/core/src/main/java/greencity/constant/ValidationConstants.java
@@ -4,6 +4,7 @@ public class ValidationConstants {
     public static final String BAD_COMMA_SEPARATED_NUMBERS =
         "Non-empty string can contain numbers separated by a comma only";
     public static final int MAX_AMOUNT_OF_TAGS = 3;
+    public static final String SEARCH_TEXT_VALIDATION_MESSAGE = "Search text must be between 3 and 64 characters";
 
     private ValidationConstants() {
     }

--- a/core/src/main/java/greencity/controller/EventController.java
+++ b/core/src/main/java/greencity/controller/EventController.java
@@ -4,17 +4,21 @@ import greencity.annotations.CurrentUser;
 import greencity.annotations.ValidImage;
 import greencity.constant.ErrorMessage;
 import greencity.constant.HttpStatuses;
+import greencity.constant.ValidationConstants;
 import greencity.dto.PageableDto;
 import greencity.dto.event.CreateEventRequestDto;
 import greencity.dto.event.EditEventRequestDto;
+import greencity.dto.event.EventPreviewDto;
 import greencity.dto.event.EventResponseDto;
 import greencity.dto.user.UserVO;
 import greencity.service.EventService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -24,14 +28,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -224,4 +221,32 @@ public class EventController {
         return ResponseEntity.noContent().build();
     }
 
+    /**
+     * Searches for events by a given keyword present in the event title.
+     * <p>
+     * This endpoint allows users to search for events using partial or full keywords. The search is case-insensitive
+     * and is performed only across event titles. The input must be between 3 and 64 characters in length.
+     * <p>
+     * Returns a list of {@link EventPreviewDto} sorted by textual relevance to the search query.
+     *
+     * @param query the keyword to search within event titles; must be 3–64 characters long
+     * @return a list of matching {@link EventPreviewDto} sorted by relevance; an empty list if no matches found
+     */
+    @Operation(
+            summary = "Search events by title",
+            description = "Allows users to search for events using a keyword that matches (partially or fully) the event title. " +
+                    "The search is case-insensitive and returns a list of matching events sorted by relevance."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST, content = @Content),
+            @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
+    })
+    @GetMapping("/search")
+    public ResponseEntity<List<EventPreviewDto>> searchEvents(
+            @RequestParam
+            @Size(min = 3, max = 64, message = ValidationConstants.SEARCH_TEXT_VALIDATION_MESSAGE)
+            String query) {
+        return ResponseEntity.ok(eventService.searchEventsByTitle(query));
+    }
 }

--- a/core/src/main/java/greencity/controller/EventController.java
+++ b/core/src/main/java/greencity/controller/EventController.java
@@ -18,7 +18,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;

--- a/core/src/main/java/greencity/controller/EventController.java
+++ b/core/src/main/java/greencity/controller/EventController.java
@@ -243,10 +243,12 @@ public class EventController {
             @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND, content = @Content)
     })
     @GetMapping("/search")
-    public ResponseEntity<List<EventPreviewDto>> searchEvents(
+    public ResponseEntity<PageableDto<EventPreviewDto>> searchEvents(
             @RequestParam
             @Size(min = 3, max = 64, message = ValidationConstants.SEARCH_TEXT_VALIDATION_MESSAGE)
-            String query) {
-        return ResponseEntity.ok(eventService.searchEventsByTitle(query));
+            String query,
+            @PageableDefault(size = 10, sort = "title") Pageable pageable
+    ) {
+        return ResponseEntity.ok(eventService.searchEventsByTitle(query, pageable));
     }
 }

--- a/dao/src/main/java/greencity/repository/EventRepo.java
+++ b/dao/src/main/java/greencity/repository/EventRepo.java
@@ -1,15 +1,12 @@
 package greencity.repository;
 
-import greencity.dto.event.EventPreviewDto;
 import greencity.entity.Event;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 

--- a/dao/src/main/java/greencity/repository/EventRepo.java
+++ b/dao/src/main/java/greencity/repository/EventRepo.java
@@ -1,10 +1,12 @@
 package greencity.repository;
 
+import greencity.dto.event.EventPreviewDto;
 import greencity.entity.Event;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,6 +15,7 @@ import java.util.Optional;
 
 @Repository
 public interface EventRepo extends JpaRepository<Event, Long> {
+    List<Event> findByTitleContainsIgnoreCase(String fragment);
 
     Optional<Event> findEventById(Long id);
 
@@ -26,6 +29,9 @@ public interface EventRepo extends JpaRepository<Event, Long> {
     @Override
     void deleteById(Long aLong);
 
-
+//    @Query("SELECT new greencity.dto.event.EventPreviewDto(e.id, e.title) " +
+//            "FROM Event e " +
+//            "WHERE LOWER(e.title) LIKE LOWER(CONCAT('%', :query, '%'))")
+//    List<EventPreviewDto> findByTitleContainingIgnoreCase(@Param("query") String query);
 
 }

--- a/dao/src/main/java/greencity/repository/EventRepo.java
+++ b/dao/src/main/java/greencity/repository/EventRepo.java
@@ -15,10 +15,10 @@ import java.util.Optional;
 
 @Repository
 public interface EventRepo extends JpaRepository<Event, Long> {
-    List<Event> findByTitleContainsIgnoreCase(String fragment);
+
+    Page<Event> findByTitleContainsIgnoreCase(String fragment, Pageable pageable);
 
     Optional<Event> findEventById(Long id);
-
 
     Page<Event> findByParticipants_Id(Long id,
                                       Pageable pageable);
@@ -28,10 +28,4 @@ public interface EventRepo extends JpaRepository<Event, Long> {
 
     @Override
     void deleteById(Long aLong);
-
-//    @Query("SELECT new greencity.dto.event.EventPreviewDto(e.id, e.title) " +
-//            "FROM Event e " +
-//            "WHERE LOWER(e.title) LIKE LOWER(CONCAT('%', :query, '%'))")
-//    List<EventPreviewDto> findByTitleContainingIgnoreCase(@Param("query") String query);
-
 }

--- a/service-api/src/main/java/greencity/dto/event/EditEventRequestDto.java
+++ b/service-api/src/main/java/greencity/dto/event/EditEventRequestDto.java
@@ -28,8 +28,6 @@ import java.util.Set;
 @EqualsAndHashCode
 public class EditEventRequestDto {
 
-    private Long eventId;
-
     @Size(max = 70)
     private String title;
 
@@ -47,5 +45,4 @@ public class EditEventRequestDto {
     @Size(min = 1, max = 7)
     @Valid
     private List<EventDateTimeDto> eventDateTimes;
-
 }

--- a/service-api/src/main/java/greencity/dto/event/EventPreviewDto.java
+++ b/service-api/src/main/java/greencity/dto/event/EventPreviewDto.java
@@ -1,0 +1,15 @@
+package greencity.dto.event;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+@Builder
+@EqualsAndHashCode
+public class EventPreviewDto {
+    private Long id;
+    private String title;
+}

--- a/service-api/src/main/java/greencity/dto/event/PageableDto.java
+++ b/service-api/src/main/java/greencity/dto/event/PageableDto.java
@@ -1,0 +1,16 @@
+package greencity.dto.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class PageableDto<T> {
+
+    private List<T> content;
+    private int totalElements;
+    private int currentPage;
+    private int totalPages;
+}

--- a/service-api/src/main/java/greencity/service/EventService.java
+++ b/service-api/src/main/java/greencity/service/EventService.java
@@ -98,6 +98,19 @@ public interface EventService {
      * @throws UserHasNoPermissionToAccessException if the user is not Admin or Owner
      */
     void deleteEventById(Long id, UserVO user);
-    
+
+    /**
+     * Retrieves a list of events that match a given search query in their titles.
+     *
+     * <p>
+     * The search is case-insensitive and matches partial titles. Only events with titles containing the
+     * provided query string will be returned. Results are sorted by textual relevance to the query.
+     * Each matching {@code Event} entity is mapped to an {@link EventPreviewDto}.
+     *
+     * @param query the search keyword used to match against event titles; must be between 3 and 64 characters
+     * @return a list of {@link EventPreviewDto} objects whose titles contain the query string;
+     *         the list may be empty if no matching events are found
+     */
+    List<EventPreviewDto> searchEventsByTitle(String query);
 }
 

--- a/service-api/src/main/java/greencity/service/EventService.java
+++ b/service-api/src/main/java/greencity/service/EventService.java
@@ -1,15 +1,15 @@
 package greencity.service;
 
 import greencity.dto.PageableDto;
-import greencity.dto.event.*;
+import greencity.dto.event.CreateEventRequestDto;
+import greencity.dto.event.EditEventRequestDto;
+import greencity.dto.event.EventPreviewDto;
+import greencity.dto.event.EventResponseDto;
 import greencity.dto.user.UserVO;
-import greencity.exception.exceptions.BadRequestException;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.exception.exceptions.UserHasNoPermissionToAccessException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 import java.util.List;
 

--- a/service-api/src/main/java/greencity/service/EventService.java
+++ b/service-api/src/main/java/greencity/service/EventService.java
@@ -111,6 +111,6 @@ public interface EventService {
      * @return a list of {@link EventPreviewDto} objects whose titles contain the query string;
      *         the list may be empty if no matching events are found
      */
-    List<EventPreviewDto> searchEventsByTitle(String query);
+    PageableDto<EventPreviewDto> searchEventsByTitle(String query, Pageable pageable);
 }
 

--- a/service/src/main/java/greencity/mapping/EditEventRequestDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/EditEventRequestDtoMapper.java
@@ -19,7 +19,6 @@ public class EditEventRequestDtoMapper extends AbstractConverter<EditEventReques
         if (dto == null) return null;
 
         Event event = Event.builder()
-                .id(dto.getEventId())
                 .title(dto.getTitle())
                 .description(dto.getDescription())
                 .eventVisibility(dto.getVisibility())

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -21,7 +21,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Service implementation for managing {@link Event} entities.
@@ -257,10 +259,41 @@ public class EventServiceImpl implements EventService {
                 .orElseThrow(() -> new NotFoundException("Event not found with id: " + id));
     }
 
-
     @PostAuthorize("hasRole('ROLE_ADMIN') or #user.id == #returnObject.creator.id")
     private Event getEventForOwnerAccess(Long eventId, UserVO user) {
         return eventRepo.findEventById(eventId)
                 .orElseThrow(() -> new NotFoundException("Event not found"));
+    }
+
+    /**
+     * Searches for events based on a provided keyword fragment in the event title.
+     * <p>
+     * The method performs a case-insensitive search across event titles, returning a list of events whose titles
+     * contain the specified query string. The results are sorted by textual relevance to the search query
+     * (i.e., the better the match in the title, the higher the event is placed in the list).
+     * Each matching {@code Event} entity is mapped to an {@link EventPreviewDto} for client display.
+     *
+     * @param query the search keyword to look for in event titles; must be between 3 and 64 characters long
+     * @return a list of {@link EventPreviewDto} that match the search query, sorted by relevance; may be empty if no matches are found
+     */
+    @Override
+    public List<EventPreviewDto> searchEventsByTitle(String query) {
+        return eventRepo.findByTitleContainsIgnoreCase(query).stream()
+                .sorted(Comparator.comparingInt((Event event) ->
+                                calculateRelevance(event.getTitle(), query))
+                        .reversed()
+                )
+                .map(event -> modelMapper.map(event, EventPreviewDto.class))
+                .collect(Collectors.toList());
+    }
+
+    private int calculateRelevance(String title, String query) {
+        title = title.toLowerCase();
+        query = query.toLowerCase();
+
+        if (title.equals(query)) return 3;
+        if (title.startsWith(query)) return 2;
+        if (title.contains(query)) return 1;
+        return 0;
     }
 }

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -277,23 +277,38 @@ public class EventServiceImpl implements EventService {
      * @return a list of {@link EventPreviewDto} that match the search query, sorted by relevance; may be empty if no matches are found
      */
     @Override
-    public List<EventPreviewDto> searchEventsByTitle(String query) {
-        return eventRepo.findByTitleContainsIgnoreCase(query).stream()
-                .sorted(Comparator.comparingInt((Event event) ->
-                                calculateRelevance(event.getTitle(), query))
+    public PageableDto<EventPreviewDto> searchEventsByTitle(String query, Pageable pageable) {
+        String normolizedQuery = query.toLowerCase();
+
+        List<EventPreviewDto> sorted = eventRepo.findByTitleContainsIgnoreCase(query, pageable).stream()
+                .sorted(Comparator.comparingInt((Event event) -> {
+                            String normalizedTitle = event.getTitle().toLowerCase();
+                            return calculateRelevance(normalizedTitle, normolizedQuery);
+                        })
                         .reversed()
                 )
                 .map(event -> modelMapper.map(event, EventPreviewDto.class))
                 .collect(Collectors.toList());
+
+        int total = sorted.size();
+        int pageSize = pageable.getPageSize();
+        int pageNumber = pageable.getPageNumber();
+        int fromIndex = pageNumber * pageSize;
+        int toIndex = Math.min(fromIndex + pageSize, total);
+
+        List<EventPreviewDto> pageContent = fromIndex >= total ? List.of() : sorted.subList(fromIndex, toIndex);
+        return new PageableDto<>(
+                pageContent,
+                total,
+                pageNumber,
+                (int) Math.ceil((double) total / pageSize)
+        );
     }
 
-    private int calculateRelevance(String title, String query) {
-        title = title.toLowerCase();
-        query = query.toLowerCase();
-
-        if (title.equals(query)) return 3;
-        if (title.startsWith(query)) return 2;
-        if (title.contains(query)) return 1;
+    private int calculateRelevance(String normalizedTitle, String normolizedQuery) {
+        if (normalizedTitle.equals(normolizedQuery)) return 3;
+        if (normalizedTitle.startsWith(normolizedQuery)) return 2;
+        if (normalizedTitle.contains(normolizedQuery)) return 1;
         return 0;
     }
 }

--- a/service/src/main/java/greencity/service/EventServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventServiceImpl.java
@@ -156,7 +156,7 @@ public class EventServiceImpl implements EventService {
         }
 
         if (images != null && !images.isEmpty()) {
-            List<EventImageDto> uploadedImages = eventImageService.uploadEventImages(images, dto.getEventId(), user);
+            List<EventImageDto> uploadedImages = eventImageService.uploadEventImages(images, eventId, user);
             uploadedImages.stream()
                     .filter(EventImageDto::getIsMain)
                     .findFirst()


### PR DESCRIPTION
This PR introduces a new endpoint that enables users to search for events by a keyword present in the event title. The search is case-insensitive and results are sorted based on textual relevance to the query.