### PR TITLE
feat: implement revoke friend request and add related tests

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -257,7 +257,8 @@ public class SecurityConfig {
                     "/social-networks",
                     USER_CUSTOM_SHOPPING_LIST_ITEMS,
                     USER_SHOPPING_LIST + "/user-shopping-list-items",
-                    "/friends/{friendId}")
+                    "/friends/{friendId}",
+                    "/friends/{friendId}/revoke")
                 .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE)
                 .requestMatchers(HttpMethod.GET,
                     "/newsSubscriber",

--- a/core/src/main/java/greencity/controller/FriendController.java
+++ b/core/src/main/java/greencity/controller/FriendController.java
@@ -134,6 +134,34 @@ public class FriendController {
     }
 
     /**
+     * Handles HTTP DELETE request to revoke a previously sent friend request.
+     * <p>
+     * This method cancels the friend request sent by the current authenticated user
+     * to the user identified by the given friendId.
+     * Upon successful execution, it returns HTTP status 200 OK with no response body.
+     *
+     * @param friendId the ID of the user whose friend request will be revoked
+     * @param userVO   the currently authenticated user (injected automatically)
+     * @return ResponseEntity with HTTP status 200 OK if the request was successfully revoked
+     */
+    @Operation(summary = "Revoke a sent friend request",
+            description = "Cancels the friend request sent by the current user to the specified friend.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Friend request successfully revoked"),
+            @ApiResponse(responseCode = "400", description = "Invalid request or friend request not found"),
+            @ApiResponse(responseCode = "404", description = "Friend user not found"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    @DeleteMapping("/{friendId}/revoke")
+    public ResponseEntity<Void> revokeFriendRequest(
+            @Parameter(description = "ID of the user whose friend request will be cancelled", required = true)
+            @PathVariable long friendId,
+            @Parameter(hidden = true) @CurrentUser UserVO userVO) {
+        friendService.revokeFriendRequest(userVO.getId(), friendId);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    /**
      * Retrieves all friends of the current user.
      *
      * @param userVO The current authenticated user.

--- a/core/src/test/java/greencity/controller/FriendControllerTest.java
+++ b/core/src/test/java/greencity/controller/FriendControllerTest.java
@@ -11,6 +11,7 @@ import greencity.enums.FriendStatus;
 import greencity.service.FriendService;
 import greencity.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -26,11 +27,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ExtendWith(MockitoExtension.class)
 class FriendControllerTest {
@@ -62,6 +61,7 @@ class FriendControllerTest {
     }
 
     @Test
+    @DisplayName("Search friends with filters should return OK")
     void searchFriends_ShouldReturnOk() throws Exception {
         PageableDto<UserCardDto> responseDto = new PageableDto<>(List.of(), 0, 0, 0);
         when(userService.findByEmail(mockUserVO.getEmail())).thenReturn(mockUserVO);
@@ -82,6 +82,7 @@ class FriendControllerTest {
     }
 
     @Test
+    @DisplayName("Send a friend request should return OK")
     void addNewFriend_ShouldReturnOk() throws Exception {
         when(userService.findByEmail(TestConst.EMAIL)).thenReturn(mockUserVO);
 
@@ -93,8 +94,8 @@ class FriendControllerTest {
         verify(friendService).sendFriendRequest(1L, 2L);
     }
 
-
     @Test
+    @DisplayName("Accept a friend request should return OK")
     void acceptFriendRequest_ShouldReturnOk() throws Exception {
         when(userService.findByEmail(TestConst.EMAIL)).thenReturn(mockUserVO);
 
@@ -107,6 +108,7 @@ class FriendControllerTest {
     }
 
     @Test
+    @DisplayName("Cancel a friend request should return OK")
     void cancelFriendRequest_ShouldReturnOk() throws Exception {
         when(userService.findByEmail(TestConst.EMAIL)).thenReturn(mockUserVO);
 
@@ -118,8 +120,8 @@ class FriendControllerTest {
         verify(friendService).cancelFriendRequest(1L, 2L);
     }
 
-
     @Test
+    @DisplayName("Get all friends should return OK")
     void getAllFriends_ShouldReturnOk() throws Exception {
         PageableDto<UserCardDto> responseDto = new PageableDto<>(List.of(), 0, 0, 0);
 
@@ -129,7 +131,7 @@ class FriendControllerTest {
         mockMvc.perform(get("/friends")
                         .param("page", "0")
                         .param("size", "10")
-                        .principal(() -> TestConst.EMAIL)  // Передаємо Principal
+                        .principal(() -> TestConst.EMAIL)
                 )
                 .andExpect(status().isOk());
 
@@ -137,6 +139,7 @@ class FriendControllerTest {
     }
 
     @Test
+    @DisplayName("Get friend status should return OK if friendship exists")
     void getFriendStatus_ShouldReturnOk() throws Exception {
         when(userService.findByEmail(TestConst.EMAIL)).thenReturn(mockUserVO);
         when(friendService.getFriendStatus(1L, 2L)).thenReturn(Optional.of(FriendStatus.FRIEND));
@@ -151,6 +154,7 @@ class FriendControllerTest {
     }
 
     @Test
+    @DisplayName("Get friend status should return NOT_FOUND if friendship does not exist")
     void getFriendStatus_ShouldReturnNotFound() throws Exception {
         when(userService.findByEmail(TestConst.EMAIL)).thenReturn(mockUserVO);
         when(friendService.getFriendStatus(1L, 2L)).thenReturn(Optional.empty());
@@ -163,4 +167,17 @@ class FriendControllerTest {
         verify(friendService).getFriendStatus(1L, 2L);
     }
 
+    @Test
+    @DisplayName("Revoke a sent friend request should return OK")
+    void revokeFriendRequest_ShouldReturnOk() throws Exception {
+        when(userService.findByEmail(TestConst.EMAIL)).thenReturn(mockUserVO);
+        doNothing().when(friendService).revokeFriendRequest(1L, 2L);
+
+        mockMvc.perform(delete("/friends/{friendId}/revoke", 2L)
+                        .principal(() -> TestConst.EMAIL)
+                )
+                .andExpect(status().isOk());
+
+        verify(friendService).revokeFriendRequest(1L, 2L);
+    }
 }

--- a/dao/src/main/java/greencity/repository/UserFriendRepository.java
+++ b/dao/src/main/java/greencity/repository/UserFriendRepository.java
@@ -145,7 +145,30 @@ public interface UserFriendRepository extends JpaRepository<UserFriend, UserFrie
     @Query(nativeQuery = true,
             value = "SELECT EXISTS(SELECT * FROM users_friends WHERE status = 'REQUEST' AND "
                     + "user_id = :friendId AND friend_id = :userId) ")
-    boolean isFriendRequestedByCurrentUser(Long userId, Long friendId);
+    boolean isFriendRequestedByFriend(Long userId, Long friendId);
+
+    /**
+     * Deletes a friend request with status 'REQUEST' from the current user to the specified friend.
+     * <p>
+     * This method removes the pending friend request record in the database.
+     *
+     * @param currentUserId the ID of the user who sent the friend request
+     * @param friendId      the ID of the user who received the friend request
+     */
+    @Modifying
+    @Query("DELETE FROM UserFriend uf WHERE uf.user.id = :currentUserId AND uf.friend.id = :friendId AND uf.status = 'REQUEST'")
+    void revokeFriendRequest(@Param("currentUserId") Long currentUserId, @Param("friendId") Long friendId);
+
+    /**
+     * Checks if a friend request with status 'REQUEST' exists from userId to friendId.
+     *
+     * @param userId   the ID of the user who may have sent the friend request
+     * @param friendId the ID of the user who may have received the friend request
+     * @return true if such a friend request exists, false otherwise
+     */
+    @Query(nativeQuery = true,
+            value = "SELECT EXISTS(SELECT 1 FROM users_friends WHERE status = 'REQUEST' AND user_id = :userId AND friend_id = :friendId)")
+    boolean isFriendRequestedByCurrentUser(@Param("userId") Long userId, @Param("friendId") Long friendId);
 
     /**
      * Accepts a friend request by updating its status to 'FRIEND'.

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -83,6 +83,7 @@ public final class ErrorMessage {
     public static final String OWN_USER_ID = "You can not perform actions with your own id : ";
     public static final String NOT_FOUND_REQUEST = "Not found friend request from user with id: ";
     public static final String NOT_FOUND_ANY_FRIENDS = "Not found any friends by id: ";
+    public static final String FRIEND_REQUEST_NOT_SENT_BY_USER = "Friend request is not sent by current user with id: ";
     public static final String FRIEND_REQUEST_NOT_SENT = "Friend Request is not sent";
     public static final String FRIEND_EXISTS = "Friend already exists with id: ";
     public static final String FRIEND_REQUEST_ALREADY_SENT = "Friend request already sent";

--- a/service-api/src/main/java/greencity/service/FriendService.java
+++ b/service-api/src/main/java/greencity/service/FriendService.java
@@ -20,5 +20,7 @@ public interface FriendService {
     Optional<FriendStatus> getFriendStatus(Long currentUserId, Long userId);
 
     void acceptFriendRequest(Long currentUserId, Long friendId);
+
+    void revokeFriendRequest(Long currentUserId, Long friendId);
 }
 

--- a/service/src/main/java/greencity/service/FriendServiceImpl.java
+++ b/service/src/main/java/greencity/service/FriendServiceImpl.java
@@ -108,6 +108,32 @@ public class FriendServiceImpl implements FriendService {
     }
 
     /**
+     * Revokes a previously sent friend request from the current user to the specified friend.
+     * The method performs the following validations before revoking the request:
+     *     Checks that the current user and friend are not the same person.
+     *     Verifies that both users exist.
+     *     Confirms that a friend request was actually sent.
+     *     Ensures the users are not already friends.
+     *     Validates that the friend request was sent by the current user.
+     * If all validations pass, the friend request is revoked in the repository.
+     *
+     * @param currentUserId the ID of the user who sent the friend request
+     * @param friendId      the ID of the user to whom the friend request was sent
+     * @throws IllegalArgumentException if any validation fails
+     */
+    @Override
+    @Transactional
+    public void revokeFriendRequest(Long currentUserId, Long friendId) {
+        validateUserAndFriendNotSamePerson(currentUserId, friendId);
+        validateUserAndFriendExistence(currentUserId, friendId);
+        validateFriendRequestWasSent(currentUserId, friendId);
+        validateFriendNotExists(currentUserId, friendId);
+        validateFriendRequestSentByCurrentUser(currentUserId, friendId);
+        userFriendRepository.revokeFriendRequest(currentUserId, friendId);
+    }
+
+
+    /**
      * Retrieves a paginated list of all friends for the current user.
      *
      * @param currentUserId ID of the user whose friends to retrieve
@@ -214,14 +240,55 @@ public class FriendServiceImpl implements FriendService {
      * @throws NotFoundException if request not found
      */
     private void validateFriendRequestSentByFriend(long userId, long friendId) {
-        if (!userFriendRepository.isFriendRequestedByCurrentUser(userId, friendId)) {
+        if (!userFriendRepository.isFriendRequestedByFriend(userId, friendId)) {
             throw new NotFoundException(ErrorMessage.FRIEND_REQUEST_NOT_SENT);
         }
     }
 
+    /**
+     * Ensures that a friendship relationship exists bidirectionally between two users.
+     * <p>
+     * This method sets the friendship status to "FRIEND" in both directions:
+     * from userId1 to userId2 and from userId2 to userId1.
+     *
+     * @param userId1 the ID of the first user
+     * @param userId2 the ID of the second user
+     */
     private void ensureBidirectionalFriendship(Long userId1, Long userId2) {
         userFriendRepository.addOrUpdateFriendRequest(userId1, userId2, "FRIEND");
         userFriendRepository.addOrUpdateFriendRequest(userId2, userId1, "FRIEND");
     }
+
+    /**
+     * Validates that a friend request with status "REQUEST" exists from userId to friendId.
+     * <p>
+     * Throws a BadRequestException if no such friend request is found.
+     *
+     * @param userId   the ID of the user who supposedly sent the friend request
+     * @param friendId the ID of the user who supposedly received the friend request
+     * @throws BadRequestException if no friend request with status "REQUEST" exists between the users
+     */
+    private void validateFriendRequestWasSent(long userId, long friendId) {
+        if (!userFriendRepository.existsFriendshipWithStatus(userId, friendId, FriendStatus.REQUEST.toString())) {
+            throw new BadRequestException(ErrorMessage.NOT_FOUND_REQUEST + friendId);
+        }
+    }
+
+    /**
+     * Validates that the friend request from userId to friendId was actually sent by the current user.
+     * <p>
+     * Throws a BadRequestException if the friend request was not sent by the user.
+     *
+     * @param userId   the ID of the user who is expected to have sent the friend request
+     * @param friendId the ID of the recipient user of the friend request
+     * @throws BadRequestException if the friend request was not sent by the specified user
+     */
+    private void validateFriendRequestSentByCurrentUser(long userId, long friendId) {
+        boolean sentByUser = userFriendRepository.isFriendRequestedByCurrentUser(userId, friendId);
+        if (!sentByUser) {
+            throw new BadRequestException(ErrorMessage.FRIEND_REQUEST_NOT_SENT_BY_USER + userId);
+        }
+    }
+
 }
 

--- a/service/src/test/java/greencity/service/FriendServiceImplTest.java
+++ b/service/src/test/java/greencity/service/FriendServiceImplTest.java
@@ -121,7 +121,7 @@ class FriendServiceImplTest {
         when(userRepo.existsById(friendId)).thenReturn(true);
         when(userFriendRepository.existsFriendshipWithStatus(currentUserId, friendId, FriendStatus.FRIEND.toString()))
                 .thenReturn(false);
-        when(userFriendRepository.isFriendRequestedByCurrentUser(currentUserId, friendId))
+        when(userFriendRepository.isFriendRequestedByFriend(currentUserId, friendId))
                 .thenReturn(true);
 
         doNothing().when(userFriendRepository).acceptFriendRequest(currentUserId, friendId);
@@ -131,7 +131,7 @@ class FriendServiceImplTest {
         verify(userRepo).existsById(currentUserId);
         verify(userRepo).existsById(friendId);
         verify(userFriendRepository).existsFriendshipWithStatus(currentUserId, friendId, FriendStatus.FRIEND.toString());
-        verify(userFriendRepository).isFriendRequestedByCurrentUser(currentUserId, friendId);
+        verify(userFriendRepository).isFriendRequestedByFriend(currentUserId, friendId);
         verify(userFriendRepository).addOrUpdateFriendRequest(currentUserId, friendId, FriendStatus.FRIEND.toString());
         verify(userFriendRepository).addOrUpdateFriendRequest(friendId, currentUserId, FriendStatus.FRIEND.toString());
     }
@@ -169,5 +169,27 @@ class FriendServiceImplTest {
         Optional<FriendStatus> result = friendService.getFriendStatus(1L, 2L);
 
         assertThat(result).contains(FriendStatus.FRIEND);
+    }
+
+    @Test
+    @DisplayName("Should successfully revoke sent friend request when all validations pass")
+    void revokeFriendRequest_success() {
+        Long currentUserId = 1L;
+        Long friendId = 2L;
+
+        when(userRepo.existsById(currentUserId)).thenReturn(true);
+        when(userRepo.existsById(friendId)).thenReturn(true);
+        when(userFriendRepository.existsFriendshipWithStatus(currentUserId, friendId, "REQUEST")).thenReturn(true);
+        when(userFriendRepository.existsFriendshipWithStatus(currentUserId, friendId, "FRIEND")).thenReturn(false);
+        when(userFriendRepository.isFriendRequestedByCurrentUser(currentUserId, friendId)).thenReturn(true);
+
+        friendService.revokeFriendRequest(currentUserId, friendId);
+
+        verify(userRepo).existsById(currentUserId);
+        verify(userRepo).existsById(friendId);
+        verify(userFriendRepository).existsFriendshipWithStatus(currentUserId, friendId, "REQUEST");
+        verify(userFriendRepository).existsFriendshipWithStatus(currentUserId, friendId, "FRIEND");
+        verify(userFriendRepository).isFriendRequestedByCurrentUser(currentUserId, friendId);
+        verify(userFriendRepository).revokeFriendRequest(currentUserId, friendId);
     }
 }


### PR DESCRIPTION
- Added endpoint in FriendController to revoke a sent friend request: DELETE /friends/{friendId}/revoke
- Implemented revokeFriendRequest(Long currentUserId, Long friendId) in FriendServiceImpl
- Created unit test for revokeFriendRequest() in FriendServiceImplTest
- Added integration test for the controller method in FriendControllerTest
- Updated SecurityConfig if necessary to allow DELETE method for the revoke endpoint